### PR TITLE
feat: analyze and document MediaWiki API MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,30 +96,117 @@ Add to your Claude Desktop configuration file:
 
 ### wiki_page_edit
 
-Edit or create MediaWiki pages with comprehensive options:
+Edit or create MediaWiki pages with comprehensive editing capabilities. This tool supports full page creation, content replacement, section editing, and text appending/prepending operations.
 
-- **Page identification**: `title` or `pageid`
-- **Content options**: `text` (full replacement), `appendtext`, `prependtext`
-- **Section editing**: `section`, `sectiontitle`
-- **Metadata**: `summary`, `minor`, `bot`, `createonly`, `nocreate`
+**Page Identification Parameters:**
+- `title` (string): Title of the page to edit. Either this or `pageid` must be provided
+- `pageid` (integer): Page ID of the page to edit. Alternative to `title` for precise page identification
+
+**Content Modification Parameters:**
+- `text` (string): Complete page content that replaces all existing content
+- `appendtext` (string): Text to append to the end of the page or specified section
+- `prependtext` (string): Text to prepend to the beginning of the page or specified section
+
+**Section Editing Parameters:**
+- `section` (string): Section to edit. Use "0" for the top section, "new" to create a new section, or a section number for existing sections
+- `sectiontitle` (string): Title for the new section when using `section="new"`
+
+**Edit Metadata Parameters:**
+- `summary` (string): Edit summary describing the changes made. Highly recommended for tracking edit history
+- `minor` (boolean): Mark edit as minor (default: false). Minor edits are typically small corrections or formatting changes
+- `bot` (boolean): Mark edit as a bot edit (default: true). Helps distinguish automated edits in page history
+
+**Page Creation/Protection Parameters:**
+- `createonly` (boolean): Only create the page if it doesn't exist. Fails if page already exists (default: false)
+- `nocreate` (boolean): Only edit existing pages. Fails if page doesn't exist (default: false)
 
 ### wiki_page_get
 
-Retrieve page information and content:
+Retrieve page information and content using multiple MediaWiki API methods optimized for different use cases. Supports various output formats and retrieval strategies.
 
-- **Input**: `title` or `pageid`
-- **Output**: Page title, ID, and full wikitext content
+**Page Identification Parameters:**
+- `title` (string): Title of the page to retrieve. Either this or `pageid` must be provided
+- `pageid` (integer): Page ID of the page to retrieve. Alternative to `title` for precise page identification
+
+**Retrieval Method Parameters:**
+- `method` (string): Retrieval strategy with different performance characteristics (default: "revisions")
+  - `"revisions"`: Uses Revisions API for complete page content with metadata. Most comprehensive but slower
+  - `"parse"`: Uses Parse API for processed content. Good for getting formatted output
+  - `"raw"`: Uses Raw API for fastest wikitext retrieval. Minimal metadata but highest performance
+  - `"extracts"`: Uses TextExtracts API for plain text summaries. Best for getting readable content excerpts
+
+**Content Format Parameters:**
+- `format` (string): Output format for content (default: "wikitext")
+  - `"wikitext"`: Raw MediaWiki markup (available for all methods)
+  - `"html"`: Parsed HTML content (only available with `method="parse"`)
+  - `"text"`: Plain text without markup (only available with `method="extracts"`)
+
+**Extract Limitation Parameters (only for `method="extracts"`):**
+- `sentences` (integer): Number of sentences to extract from the beginning of the page
+- `chars` (integer): Character limit for extract length. Cannot be used simultaneously with `sentences`
 
 ### wiki_search
 
-Advanced search functionality with MediaWiki's search API:
+Comprehensive search functionality using MediaWiki's advanced search API with extensive filtering, sorting, and result customization options.
 
-- **Query**: Search terms (required)
-- **Filtering**: `namespaces`, `what` (text/title/nearmatch)
-- **Pagination**: `limit`, `offset`
-- **Results**: `prop` (snippet, size, timestamp, etc.)
-- **Sorting**: Multiple sort options
-- **Advanced**: Query rewriting, interwiki results
+**Core Search Parameters:**
+- `query` (string): **Required.** Search query string using MediaWiki search syntax
+
+**Namespace Filtering Parameters:**
+- `namespaces` (array of integers): List of namespace IDs to search within (default: [0] for main namespace)
+  - Common namespaces: 0 (Main), 1 (Talk), 2 (User), 3 (User talk), 4 (Project), 6 (File), 10 (Template), 14 (Category)
+
+**Search Type Parameters:**
+- `what` (string): Type of search to perform (default: "text")
+  - `"text"`: Full-text search in page content
+  - `"title"`: Search only in page titles
+  - `"nearmatch"`: Find pages with titles closely matching the query
+
+**Pagination Parameters:**
+- `limit` (integer): Maximum number of results to return. Range: 1-500 (default: 10)
+- `offset` (integer): Starting position for results, enabling pagination (default: 0)
+
+**Result Properties Parameters:**
+- `prop` (array of strings): Properties to include for each search result
+  - `"categorysnippet"`: Snippet showing category matches
+  - `"extensiondata"`: Additional extension-specific data
+  - `"isfilematch"`: Whether the match is in file content
+  - `"redirectsnippet"`: Snippet from redirect pages
+  - `"redirecttitle"`: Title of redirect source
+  - `"sectionsnippet"`: Snippet from specific page sections
+  - `"sectiontitle"`: Title of matching sections
+  - `"size"`: Page size in bytes
+  - `"snippet"`: Highlighted search result snippet
+  - `"timestamp"`: Last edit timestamp
+  - `"titlesnippet"`: Highlighted title snippet
+  - `"wordcount"`: Number of words in the page
+
+**Search Metadata Parameters:**
+- `info` (array of strings): Metadata to return about the search
+  - `"rewrittenquery"`: Shows how the search engine rewrote the query
+  - `"suggestion"`: Alternative query suggestions
+  - `"totalhits"`: Total number of matching pages
+
+**Advanced Search Parameters:**
+- `sort` (string): Sort order for results (default: "relevance")
+  - `"relevance"`: Sort by search relevance score
+  - `"create_timestamp_asc"` / `"create_timestamp_desc"`: Sort by page creation date
+  - `"last_edit_asc"` / `"last_edit_desc"`: Sort by last edit timestamp
+  - `"incoming_links_asc"` / `"incoming_links_desc"`: Sort by number of incoming links
+  - `"just_match"`: Return only matching results without sorting
+  - `"none"`: No specific sort order
+  - `"random"` / `"user_random"`: Random ordering
+
+**Search Enhancement Parameters:**
+- `enable_rewrites` (boolean): Enable internal query rewriting for improved results (default: true)
+- `interwiki` (boolean): Include results from other wikis if interwiki search is configured (default: false)
+- `qiprofile` (string): Query-independent ranking profile (default: "engine_autoselect")
+  - `"engine_autoselect"`: Let the search engine choose the best profile
+  - `"classic"`: Traditional MediaWiki search ranking
+  - `"classic_noboostlinks"`: Classic ranking without link boost
+  - `"popular_inclinks"`: Boost pages with more incoming links
+  - `"popular_inclinks_pv"`: Boost popular pages with incoming links and page views
+  - `"wsum_inclinks"` / `"wsum_inclinks_pv"`: Weighted sum algorithms with link metrics
 
 ## Development
 


### PR DESCRIPTION
Analyze all the available mediawiki-api-mcp tools and improve the "Tools" section in the README file, exhaustively and accurately documenting and detailing all parameters and options.

```git-revs
f6807c6  (Base revision)
HEAD     Improve Tools section with comprehensive parameter documentation
```

codemcp-id: 9-feat-analyze-and-document-mediawiki-api-mcp-tools

---

## Documentation Improvements

### Enhanced README Tools Section

I replaced the basic tool descriptions with comprehensive parameter documentation that includes:

- Detailed parameter categorization (Page Identification, Content Modification, etc.)
- Complete parameter descriptions with data types and constraints
- Default values and valid ranges
- Usage guidance for different parameter combinations
- Method-specific parameter availability (e.g., format options per retrieval method)