### PR TITLE
fix: resolve ImportError for 'app' and 'get_config' in server tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import pytest
 
 from mediawiki_api_mcp.client import MediaWikiClient, MediaWikiConfig
 from mediawiki_api_mcp.handlers import handle_edit_page, handle_get_page, handle_search
-from mediawiki_api_mcp.server import app, get_config
+from mediawiki_api_mcp.server import mcp, get_config
 
 
 @pytest.fixture
@@ -347,7 +347,7 @@ class TestExistingFunctionality:
 @pytest.mark.asyncio
 async def test_list_tools():
     """Test that search tool is included in tool list."""
-    tools = await app.list_tools()
+    tools = await mcp.list_tools()
 
     tool_names = [tool.name for tool in tools]
     assert "wiki_search" in tool_names


### PR DESCRIPTION
Fix following error when trying to run the tests:

```
ImportError while importing test module '/usr/local/var/www/entanglr/mediawiki-api-mcp/tests/test_server.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Users/allcos/.pyenv/versions/3.10.0/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_server.py:10: in <module>
    from mediawiki_api_mcp.server import app, get_config
E   ImportError: cannot import name 'app' from 'mediawiki_api_mcp.server' (/usr/local/var/www/entanglr/mediawiki-api-mcp/mediawiki_api_mcp/server.py)
```

```git-revs
ea11fa1  (Base revision)
3e7dd86  Add app alias for mcp instance to fix ImportError in tests
c810ec9  Update test imports to use mcp instead of app
HEAD     Update test to use mcp instead of app for list_tools call
```

codemcp-id: 12-fix-resolve-importerror-for-app-and-get-config-in-