### PR TITLE
fix: resolve mypy type error in client.py line 390

### DIFF
--- a/mediawiki_api_mcp/client.py
+++ b/mediawiki_api_mcp/client.py
@@ -387,7 +387,7 @@ class MediaWikiClient:
             params["srnamespace"] = "|".join(str(ns) for ns in namespaces)
 
         # Set limits and pagination
-        params["srlimit"] = max(1, min(500, limit))
+        params["srlimit"] = str(max(1, min(500, limit)))
         if offset > 0:
             params["sroffset"] = str(offset)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -274,7 +274,7 @@ class TestSearchFunctionality:
                 "srsearch": "test query",
                 "format": "json",
                 "srnamespace": "0",
-                "srlimit": 10,
+                "srlimit": "10",
                 "srwhat": "text",
                 "srqiprofile": "engine_autoselect",
                 "srinfo": "totalhits|suggestion|rewrittenquery",


### PR DESCRIPTION
Fix the mypy error at line 390 in mediawiki_api_mcp/client.py where there's an incompatible types assignment (expression has type "int", target has type "str")

```git-revs
91e9cf2  (Base revision)
205a4ab  Fix mypy type error by converting integer limit to string for API parameter
HEAD     Update test to expect string value for srlimit parameter
```

codemcp-id: 17-fix-resolve-mypy-type-error-in-client-py-line-390