### PR TITLE
feat: implement `wiki_page_move` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The server provides various MCP tools with the `wiki_` prefix:
 
 - **`wiki_page_edit`**: Edit or create MediaWiki pages with comprehensive editing options
 - **`wiki_page_get`**: Retrieve page information and content
+- **`wiki_page_move`**: Move pages with support for talk pages, subpages, and redirects
 - **`wiki_search`**: Search for pages using MediaWiki's search API with advanced filtering
 - **`wiki_opensearch`**: Search using OpenSearch protocol for quick suggestions and autocomplete
 
@@ -24,11 +25,13 @@ mediawiki_api_mcp/
 │   ├── __init__.py
 │   ├── wiki_page_edit.py   # Edit page tools
 │   ├── wiki_page_get.py    # Get page tools
+│   ├── wiki_page_move.py   # Move page tools
 │   └── wiki_search.py      # Search tools
 └── handlers/               # Tool handlers
     ├── __init__.py
     ├── wiki_page_edit.py   # Edit page handlers
     ├── wiki_page_get.py    # Get page handlers
+    ├── wiki_page_move.py   # Move page handlers
     ├── wiki_search.py      # Search handlers
     └── wiki_opensearch.py  # OpenSearch handlers
 
@@ -37,6 +40,7 @@ tests/
 ├── test_server.py          # Integration tests
 ├── test_wiki_page_edit.py  # Edit handler tests
 ├── test_wiki_page_get.py   # Get handler tests
+├── test_wiki_page_move.py  # Move handler tests
 ├── test_wiki_search.py     # Search handler tests
 ├── test_wiki_opensearch.py # OpenSearch handler tests
 └── test_tools.py           # Tool definition tests
@@ -185,6 +189,43 @@ Retrieve page information and content using multiple MediaWiki API methods optim
 **Extract Limitation Parameters (only for `method="extracts"`):**
 - `sentences` (integer): Number of sentences to extract from the beginning of the page
 - `chars` (integer): Character limit for extract length. Cannot be used simultaneously with `sentences`
+
+### wiki_page_move
+
+Move a page with comprehensive options for handling talk pages, subpages, and redirects. This tool enables renaming pages while maintaining proper link structure and history preservation.
+
+**Page Identification Parameters:**
+- `from_title` (string): Title of the page to rename. Cannot be used together with `fromid`
+- `fromid` (integer): Page ID of the page to rename. Cannot be used together with `from_title`. Useful for precisely identifying pages with special characters or ambiguous titles
+- `to` (string): **Required.** Title to rename the page to. Must be a valid page title in the destination namespace
+
+**Move Reason Parameters:**
+- `reason` (string): Reason for the rename. This appears in the move log and helps other editors understand the purpose of the move
+
+**Associated Content Parameters:**
+- `movetalk` (boolean): Rename the talk page, if it exists (default: false). Automatically moves the associated discussion page
+- `movesubpages` (boolean): Rename subpages, if applicable (default: false). Moves all subpages that follow the pattern `OriginalPage/Subpage`
+
+**Redirect Handling Parameters:**
+- `noredirect` (boolean): Don't create a redirect from the old page name (default: false). Requires special permissions (typically bot or sysop rights)
+
+**Watchlist Management Parameters:**
+- `watchlist` (string): Watchlist behavior for the moved page (default: "preferences")
+  - `"nochange"`: Don't change current watchlist status
+  - `"preferences"`: Use user preferences (typically ignored for bot users)
+  - `"unwatch"`: Remove from watchlist
+  - `"watch"`: Add to watchlist
+- `watchlistexpiry` (string): Watchlist expiry timestamp in ISO 8601 format. Omit to leave current expiry unchanged
+
+**Advanced Parameters:**
+- `ignorewarnings` (boolean): Ignore any warnings that would normally prevent the move (default: false)
+- `tags` (string): Change tags to apply to the move log entry and destination page. Multiple tags separated by pipe (`|`) character
+
+**Important Notes:**
+- The `noredirect` option requires the `suppressredirect` right, typically granted to bots and sysops
+- If redirect suppression is attempted without proper rights, the API will create a redirect without returning an error
+- Subpage moves may fail individually while the main page move succeeds; check response for detailed status
+- Some namespaces may be protected from moves (e.g., MediaWiki namespace)
 
 ### wiki_search
 

--- a/mediawiki_api_mcp/handlers/__init__.py
+++ b/mediawiki_api_mcp/handlers/__init__.py
@@ -3,6 +3,7 @@
 from .wiki_opensearch import handle_opensearch
 from .wiki_page_edit import handle_edit_page
 from .wiki_page_get import handle_get_page
+from .wiki_page_move import handle_move_page
 from .wiki_search import handle_search
 
-__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch"]
+__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch", "handle_move_page"]

--- a/mediawiki_api_mcp/handlers/wiki_page_move.py
+++ b/mediawiki_api_mcp/handlers/wiki_page_move.py
@@ -1,0 +1,99 @@
+"""MediaWiki move handlers for MCP server."""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import mcp.types as types
+
+from ..client import MediaWikiClient
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_move_page(
+    client: MediaWikiClient,
+    arguments: dict[str, Any]
+) -> Sequence[types.TextContent]:
+    """Handle wiki_page_move tool calls."""
+    from_title = arguments.get("from")
+    fromid = arguments.get("fromid")
+    to = arguments.get("to")
+
+    if not from_title and not fromid:
+        return [types.TextContent(
+            type="text",
+            text="Error: Either 'from' or 'fromid' must be provided"
+        )]
+
+    if not to:
+        return [types.TextContent(
+            type="text",
+            text="Error: 'to' parameter is required"
+        )]
+
+    # Extract move parameters
+    move_params = {
+        "from_title": from_title,
+        "fromid": fromid,
+        "to": to,
+        "reason": arguments.get("reason"),
+        "movetalk": arguments.get("movetalk", False),
+        "movesubpages": arguments.get("movesubpages", False),
+        "noredirect": arguments.get("noredirect", False),
+        "watchlist": arguments.get("watchlist", "preferences"),
+        "watchlistexpiry": arguments.get("watchlistexpiry"),
+        "ignorewarnings": arguments.get("ignorewarnings", False),
+        "tags": arguments.get("tags")
+    }
+
+    # Remove None values
+    move_params = {k: v for k, v in move_params.items() if v is not None}
+
+    try:
+        result = await client.move_page(**move_params)
+
+        # Check if the move was successful
+        if "from" in result and "to" in result:
+            from_page = result.get("from", from_title or f"Page ID {fromid}")
+            to_page = result.get("to", to)
+            reason = result.get("reason", "No reason provided")
+
+            response_text = f"Successfully moved page '{from_page}' to '{to_page}'"
+            if reason:
+                response_text += f". Reason: {reason}"
+
+            # Include talk page move info if applicable
+            if "talkfrom" in result and "talkto" in result:
+                response_text += f". Talk page moved from '{result['talkfrom']}' to '{result['talkto']}'"
+
+            # Include subpage move info if applicable
+            if "subpages" in result:
+                subpage_count = len(result["subpages"])
+                response_text += f". {subpage_count} subpages moved"
+
+            return [types.TextContent(
+                type="text",
+                text=response_text
+            )]
+        else:
+            # Handle error responses
+            if "error" in result:
+                error_info = result["error"]
+                error_code = error_info.get("code", "unknown")
+                error_message = error_info.get("info", "Unknown error")
+                return [types.TextContent(
+                    type="text",
+                    text=f"Move failed ({error_code}): {error_message}"
+                )]
+            else:
+                return [types.TextContent(
+                    type="text",
+                    text=f"Move failed: {result}"
+                )]
+
+    except Exception as e:
+        return [types.TextContent(
+            type="text",
+            text=f"Error moving page: {str(e)}"
+        )]

--- a/mediawiki_api_mcp/server.py
+++ b/mediawiki_api_mcp/server.py
@@ -243,6 +243,64 @@ async def wiki_opensearch(
         return f"Error: {str(e)}"
 
 
+@mcp.tool()
+async def wiki_page_move(
+    from_title: str = "",
+    fromid: int = 0,
+    to: str = "",
+    reason: str = "",
+    movetalk: bool = False,
+    movesubpages: bool = False,
+    noredirect: bool = False,
+    watchlist: str = "preferences",
+    watchlistexpiry: str = "",
+    ignorewarnings: bool = False,
+    tags: str = "",
+) -> str:
+    """Move a page.
+
+    Args:
+        from_title: Title of the page to rename. Cannot be used together with fromid.
+        fromid: Page ID of the page to rename. Cannot be used together with from.
+        to: Title to rename the page to.
+        reason: Reason for the rename.
+        movetalk: Rename the talk page, if it exists.
+        movesubpages: Rename subpages, if applicable.
+        noredirect: Don't create a redirect.
+        watchlist: Unconditionally add or remove the page from the current user's watchlist, use preferences (ignored for bot users) or do not change watch.
+        watchlistexpiry: Watchlist expiry timestamp. Omit this parameter entirely to leave the current expiry unchanged.
+        ignorewarnings: Ignore any warnings.
+        tags: Change tags to apply to the entry in the move log and to the null revision on the destination page.
+    """
+    try:
+        config = get_config()
+        async with MediaWikiClient(config) as client:
+            # Import here to avoid circular imports
+            from .handlers import handle_move_page
+
+            # Convert FastMCP parameters to handler arguments
+            arguments = {
+                "from": from_title if from_title else None,
+                "fromid": fromid if fromid else None,
+                "to": to if to else None,
+                "reason": reason if reason else None,
+                "movetalk": movetalk,
+                "movesubpages": movesubpages,
+                "noredirect": noredirect,
+                "watchlist": watchlist if watchlist != "preferences" else None,
+                "watchlistexpiry": watchlistexpiry if watchlistexpiry else None,
+                "ignorewarnings": ignorewarnings,
+                "tags": tags.split("|") if tags else None,
+            }
+
+            result = await handle_move_page(client, arguments)
+            # Return the formatted text from the handler
+            return result[0].text if result else "No results"
+    except Exception as e:
+        logger.error(f"Wiki page move failed: {e}")
+        return f"Error: {str(e)}"
+
+
 def run_server() -> None:
     """Synchronous entry point for the MCP server."""
     mcp.run(transport='stdio')

--- a/mediawiki_api_mcp/tools/__init__.py
+++ b/mediawiki_api_mcp/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from .wiki_page_edit import get_edit_tools
 from .wiki_page_get import get_page_tools
+from .wiki_page_move import get_move_tools
 from .wiki_search import get_search_tools
 
-__all__ = ["get_edit_tools", "get_page_tools", "get_search_tools"]
+__all__ = ["get_edit_tools", "get_page_tools", "get_search_tools", "get_move_tools"]

--- a/mediawiki_api_mcp/tools/wiki_page_move.py
+++ b/mediawiki_api_mcp/tools/wiki_page_move.py
@@ -1,0 +1,69 @@
+"""MediaWiki move tools definition."""
+
+import mcp.types as types
+
+
+def get_move_tools() -> list[types.Tool]:
+    """Get move-related MediaWiki tools."""
+    return [
+        types.Tool(
+            name="wiki_page_move",
+            description="Move a page",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "from_title": {
+                        "type": "string",
+                        "description": "Title of the page to rename. Cannot be used together with fromid."
+                    },
+                    "fromid": {
+                        "type": "integer",
+                        "description": "Page ID of the page to rename. Cannot be used together with from."
+                    },
+                    "to": {
+                        "type": "string",
+                        "description": "Title to rename the page to."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Reason for the rename."
+                    },
+                    "movetalk": {
+                        "type": "boolean",
+                        "description": "Rename the talk page, if it exists.",
+                        "default": False
+                    },
+                    "movesubpages": {
+                        "type": "boolean",
+                        "description": "Rename subpages, if applicable.",
+                        "default": False
+                    },
+                    "noredirect": {
+                        "type": "boolean",
+                        "description": "Don't create a redirect.",
+                        "default": False
+                    },
+                    "watchlist": {
+                        "type": "string",
+                        "description": "Unconditionally add or remove the page from the current user's watchlist, use preferences (ignored for bot users) or do not change watch.",
+                        "enum": ["nochange", "preferences", "unwatch", "watch"],
+                        "default": "preferences"
+                    },
+                    "watchlistexpiry": {
+                        "type": "string",
+                        "description": "Watchlist expiry timestamp. Omit this parameter entirely to leave the current expiry unchanged."
+                    },
+                    "ignorewarnings": {
+                        "type": "boolean",
+                        "description": "Ignore any warnings.",
+                        "default": False
+                    },
+                    "tags": {
+                        "type": "string",
+                        "description": "Change tags to apply to the entry in the move log and to the null revision on the destination page."
+                    }
+                },
+                "required": ["to"]
+            }
+        )
+    ]

--- a/tests/test_wiki_page_move.py
+++ b/tests/test_wiki_page_move.py
@@ -1,0 +1,144 @@
+"""Test suite for MediaWiki move handlers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mediawiki_api_mcp.client import MediaWikiClient
+from mediawiki_api_mcp.handlers.wiki_page_move import handle_move_page
+
+
+class TestMoveHandlers:
+    """Test cases for move-related handlers."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock MediaWiki client."""
+        client = MagicMock(spec=MediaWikiClient)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_success(self, mock_client):
+        """Test successful page move."""
+        # Setup mock response
+        mock_client.move_page.return_value = {
+            "from": "Old Title",
+            "to": "New Title",
+            "reason": "Test move"
+        }
+
+        arguments = {
+            "from": "Old Title",
+            "to": "New Title",
+            "reason": "Test move"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Successfully moved page 'Old Title' to 'New Title'" in result[0].text
+        assert "Reason: Test move" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_with_talk(self, mock_client):
+        """Test page move with talk page."""
+        # Setup mock response
+        mock_client.move_page.return_value = {
+            "from": "Old Title",
+            "to": "New Title",
+            "reason": "Test move",
+            "talkfrom": "Talk:Old Title",
+            "talkto": "Talk:New Title"
+        }
+
+        arguments = {
+            "from": "Old Title",
+            "to": "New Title",
+            "reason": "Test move",
+            "movetalk": True
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Successfully moved page 'Old Title' to 'New Title'" in result[0].text
+        assert "Talk page moved from 'Talk:Old Title' to 'Talk:New Title'" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_missing_from_params(self, mock_client):
+        """Test move page with missing from parameters."""
+        arguments = {
+            "to": "New Title"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Error: Either 'from' or 'fromid' must be provided" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_missing_to_param(self, mock_client):
+        """Test move page with missing to parameter."""
+        arguments = {
+            "from": "Old Title"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Error: 'to' parameter is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_error_response(self, mock_client):
+        """Test move page with error response."""
+        mock_client.move_page.return_value = {
+            "error": {
+                "code": "cantmove",
+                "info": "You don't have permission to move this page"
+            }
+        }
+
+        arguments = {
+            "from": "Old Title",
+            "to": "New Title"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Move failed (cantmove): You don't have permission to move this page" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_exception(self, mock_client):
+        """Test move page with client exception."""
+        mock_client.move_page.side_effect = Exception("Network error")
+
+        arguments = {
+            "from": "Old Title",
+            "to": "New Title"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Error moving page: Network error" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_move_page_with_fromid(self, mock_client):
+        """Test page move using page ID."""
+        # Setup mock response
+        mock_client.move_page.return_value = {
+            "from": "Old Title",
+            "to": "New Title",
+            "reason": ""
+        }
+
+        arguments = {
+            "fromid": 12345,
+            "to": "New Title"
+        }
+
+        result = await handle_move_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Successfully moved page 'Old Title' to 'New Title'" in result[0].text


### PR DESCRIPTION
Implement `wiki_page_move` tool

```git-revs
93fc9d4  (Base revision)
269f1b6  Add move_page method to MediaWikiClient for page moving functionality
f84d4c8  Create handler for wiki_page_move tool
c96d0f9  Add handle_move_page import to handlers __init__.py
052f24c  Add wiki_page_move tool to server.py
1ca215d  Create test file for wiki_page_move handler
74a5575  Fix syntax error in move_page method signature
5701324  Create tool definition for wiki_page_move
29632fa  Add get_move_tools import to tools __init__.py
8fc95eb  Update README.md to include wiki_page_move tool
379187b  Update Project Structure in README to include move functionality
HEAD     Add wiki_page_move tool documentation to README
```

codemcp-id: 22-feat-implement-mediawiki-api-mcp-server-with-wiki-

---

Test Run Summary for `wiki_page_move` Tool:

1. Initial Page Creation:
   - Page titled `Foo` was successfully created
   - Initial content: "This is a test page created to demonstrate the wiki_page_move functionality."

2. Page Move Operation:
   - Page was successfully moved from `Foo` to `Lorem Ipsum`
   - Reason for move: "Testing wiki_page_move tool functionality"

3. Redirect Verification:
   - The original page `Foo` now contains a redirect to `Lorem Ipsum`
   - Redirect syntax: `#REDIRECT [[Lorem Ipsum]]`

4. Conclusion:
   - The `wiki_page_move` tool worked as expected
   - All operations (page creation, moving, and redirect) were completed successfully