### PR TITLE
feat: implement `wiki_page_undelete` tool

### DIFF
--- a/docs/tools/wiki_page_undelete.md
+++ b/docs/tools/wiki_page_undelete.md
@@ -1,0 +1,50 @@
+### wiki_page_undelete
+
+Undelete (restore) deleted MediaWiki pages with comprehensive restoration options including selective revision restoration, talk page recovery, and detailed logging. This tool provides full access to MediaWiki's undelete API functionality.
+
+**Page Identification Parameters:**
+- `title` (string, required): Title of the page to undelete. This must be the exact title of the deleted page as it appears in the deletion log
+
+**Restoration Reason Parameters:**
+- `reason` (string): Reason for restoring the page (default: empty). This appears in the deletion log and helps other editors understand the purpose of the restoration
+
+**Selective Restoration Parameters:**
+- `timestamps` (string): Pipe-separated list of timestamps of specific revisions to undelete (e.g., "2023-01-01T12:00:00Z|2023-01-02T15:30:00Z"). If both `timestamps` and `fileids` are empty, all revisions will be undeleted
+- `fileids` (string): Pipe-separated list of file revision IDs to restore for file pages (e.g., "123|456"). If both `timestamps` and `fileids` are empty, all file versions will be restored
+
+**Associated Content Parameters:**
+- `undeletetalk` (boolean): Undelete all revisions of the associated talk page, if any (default: false). Automatically restores the discussion page related to the undeleted page
+
+**Change Tracking Parameters:**
+- `tags` (string): Pipe-separated list of change tags to apply to the entry in the deletion log (e.g., "restoration|admin-action"). Helps categorize and track different types of restorations for administrative purposes
+
+**Watchlist Management Parameters:**
+- `watchlist` (string): Watchlist behavior for the restored page (default: "preferences")
+  - `"nochange"`: Don't change current watchlist status
+  - `"preferences"`: Use user preferences (typically ignored for bot users)
+  - `"unwatch"`: Remove from watchlist after restoration
+  - `"watch"`: Add to watchlist after restoration
+- `watchlistexpiry` (string): Watchlist expiry timestamp in ISO 8601 format. Omit to leave current expiry unchanged
+
+**Response Information:**
+The tool returns information about the restoration including:
+- Page title that was restored
+- Reason used for the restoration
+- Number of revisions restored
+- Number of file versions restored (for file pages)
+
+**Important Notes:**
+- The `title` parameter is required and must exactly match the deleted page title
+- Undelete operations require appropriate permissions (undelete rights) in the MediaWiki installation
+- The restoration is logged in the deletion log with the provided reason and any specified tags
+- Selective restoration using `timestamps` or `fileids` allows for partial recovery of page history
+- Talk page restoration with `undeletetalk` requires separate permissions and may fail even if the main page restoration succeeds
+- If no specific revisions are specified via `timestamps` or `fileids`, all available revisions will be restored
+- File pages can have both page revisions and file revisions, which are handled separately
+- Some revisions may not be restorable if they have been permanently deleted or if there are permission restrictions
+
+**Usage Examples:**
+- Full restoration: `{"title": "Example Page", "reason": "Accidental deletion"}`
+- Selective restoration: `{"title": "Example Page", "timestamps": "2023-01-01T12:00:00Z|2023-01-02T15:30:00Z", "reason": "Restore specific versions"}`
+- File restoration: `{"title": "File:Example.jpg", "fileids": "123|456", "reason": "Restore file versions"}`
+- Complete restoration with talk page: `{"title": "Example Page", "undeletetalk": true, "reason": "Full restoration needed"}`

--- a/mediawiki_api_mcp/handlers/__init__.py
+++ b/mediawiki_api_mcp/handlers/__init__.py
@@ -5,6 +5,7 @@ from .wiki_page_delete import handle_delete_page
 from .wiki_page_edit import handle_edit_page
 from .wiki_page_get import handle_get_page
 from .wiki_page_move import handle_move_page
+from .wiki_page_undelete import handle_undelete_page
 from .wiki_search import handle_search
 
-__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page"]
+__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page", "handle_undelete_page"]

--- a/mediawiki_api_mcp/handlers/wiki_page_undelete.py
+++ b/mediawiki_api_mcp/handlers/wiki_page_undelete.py
@@ -1,0 +1,76 @@
+"""MediaWiki undelete handlers for MCP server."""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import mcp.types as types
+
+from ..client import MediaWikiClient
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_undelete_page(
+    client: MediaWikiClient,
+    arguments: dict[str, Any]
+) -> Sequence[types.TextContent]:
+    """Handle wiki_page_undelete tool calls."""
+    title = arguments.get("title")
+
+    if not title:
+        return [types.TextContent(
+            type="text",
+            text="Error: 'title' parameter is required"
+        )]
+
+    # Extract undelete parameters
+    undelete_params = {
+        "title": title,
+    }
+
+    # Add optional parameters only if they're provided and not defaults
+    if arguments.get("reason"):
+        undelete_params["reason"] = arguments["reason"]
+    if arguments.get("tags"):
+        undelete_params["tags"] = arguments["tags"]
+    if arguments.get("timestamps"):
+        undelete_params["timestamps"] = arguments["timestamps"]
+    if arguments.get("fileids"):
+        undelete_params["fileids"] = arguments["fileids"]
+    if arguments.get("undeletetalk", False):
+        undelete_params["undeletetalk"] = arguments["undeletetalk"]
+    if arguments.get("watchlist") and arguments["watchlist"] != "preferences":
+        undelete_params["watchlist"] = arguments["watchlist"]
+    if arguments.get("watchlistexpiry"):
+        undelete_params["watchlistexpiry"] = arguments["watchlistexpiry"]
+
+    try:
+        result = await client.undelete_page(**undelete_params)
+
+        if "title" in result:
+            page_title = result.get("title", title)
+            reason_used = result.get("reason", "No reason provided")
+            revisions = result.get("revisions", 0)
+            fileversions = result.get("fileversions", 0)
+
+            response_text = f"Successfully undeleted page '{page_title}'. "
+            response_text += f"Reason: {reason_used}. "
+            response_text += f"Revisions restored: {revisions}. "
+            response_text += f"File versions restored: {fileversions}."
+
+            return [types.TextContent(
+                type="text",
+                text=response_text
+            )]
+        else:
+            return [types.TextContent(
+                type="text",
+                text=f"Undelete failed: {result}"
+            )]
+
+    except Exception as e:
+        return [types.TextContent(
+            type="text",
+            text=f"Error undeleting page: {str(e)}"
+        )]

--- a/mediawiki_api_mcp/server.py
+++ b/mediawiki_api_mcp/server.py
@@ -356,6 +356,55 @@ async def wiki_page_delete(
         return f"Error: {str(e)}"
 
 
+@mcp.tool()
+async def wiki_page_undelete(
+    title: str,
+    reason: str = "",
+    tags: str = "",
+    timestamps: str = "",
+    fileids: str = "",
+    undeletetalk: bool = False,
+    watchlist: str = "preferences",
+    watchlistexpiry: str = "",
+) -> str:
+    """Undelete (restore) the revisions of a deleted page.
+
+    Args:
+        title: Title of the page to undelete (required).
+        reason: Reason for restoring.
+        tags: Change tags to apply to the entry in the deletion log (separate with |).
+        timestamps: Timestamps of the revisions to undelete (separate with |). If both timestamps and fileids are empty, all will be undeleted.
+        fileids: IDs of the file revisions to restore (separate with |). If both timestamps and fileids are empty, all will be restored.
+        undeletetalk: Undelete all revisions of the associated talk page, if any.
+        watchlist: Unconditionally add or remove the page from the current user's watchlist, use preferences (ignored for bot users) or do not change watch.
+        watchlistexpiry: Watchlist expiry timestamp. Omit this parameter entirely to leave the current expiry unchanged.
+    """
+    try:
+        config = get_config()
+        async with MediaWikiClient(config) as client:
+            # Import here to avoid circular imports
+            from .handlers import handle_undelete_page
+
+            # Convert FastMCP parameters to handler arguments
+            arguments = {
+                "title": title,
+                "reason": reason if reason else None,
+                "tags": tags.split("|") if tags else None,
+                "timestamps": timestamps.split("|") if timestamps else None,
+                "fileids": [int(x) for x in fileids.split("|")] if fileids else None,
+                "undeletetalk": undeletetalk,
+                "watchlist": watchlist if watchlist != "preferences" else None,
+                "watchlistexpiry": watchlistexpiry if watchlistexpiry else None,
+            }
+
+            result = await handle_undelete_page(client, arguments)
+            # Return the formatted text from the handler
+            return result[0].text if result else "No results"
+    except Exception as e:
+        logger.error(f"Wiki page undelete failed: {e}")
+        return f"Error: {str(e)}"
+
+
 def run_server() -> None:
     """Synchronous entry point for the MCP server."""
     mcp.run(transport='stdio')

--- a/tests/test_wiki_page_undelete.py
+++ b/tests/test_wiki_page_undelete.py
@@ -1,0 +1,258 @@
+"""Tests for wiki page undelete functionality."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mediawiki_api_mcp.client import MediaWikiClient
+from mediawiki_api_mcp.handlers.wiki_page_undelete import handle_undelete_page
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock MediaWiki client."""
+    client = AsyncMock(spec=MediaWikiClient)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_success(mock_client):
+    """Test successful page undelete."""
+    # Mock successful undelete response
+    mock_client.undelete_page.return_value = {
+        "title": "Test Page",
+        "reason": "Test restoration",
+        "revisions": 2,
+        "fileversions": 0
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Test restoration"
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'Test Page'" in result[0].text
+    assert "Test restoration" in result[0].text
+    assert "Revisions restored: 2" in result[0].text
+    assert "File versions restored: 0" in result[0].text
+    mock_client.undelete_page.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_with_timestamps(mock_client):
+    """Test page undelete with specific timestamps."""
+    mock_client.undelete_page.return_value = {
+        "title": "Test Page",
+        "reason": "Selective restoration",
+        "revisions": 1,
+        "fileversions": 0
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Selective restoration",
+        "timestamps": ["2023-01-01T12:00:00Z"]
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'Test Page'" in result[0].text
+    assert "Selective restoration" in result[0].text
+    assert "Revisions restored: 1" in result[0].text
+    mock_client.undelete_page.assert_called_once_with(
+        title="Test Page",
+        reason="Selective restoration",
+        timestamps=["2023-01-01T12:00:00Z"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_with_fileids(mock_client):
+    """Test page undelete with specific file IDs."""
+    mock_client.undelete_page.return_value = {
+        "title": "File:Test.jpg",
+        "reason": "File restoration",
+        "revisions": 0,
+        "fileversions": 2
+    }
+
+    arguments = {
+        "title": "File:Test.jpg",
+        "reason": "File restoration",
+        "fileids": [123, 456]
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'File:Test.jpg'" in result[0].text
+    assert "File restoration" in result[0].text
+    assert "File versions restored: 2" in result[0].text
+    mock_client.undelete_page.assert_called_once_with(
+        title="File:Test.jpg",
+        reason="File restoration",
+        fileids=[123, 456]
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_with_undeletetalk(mock_client):
+    """Test page undelete with talk page restoration."""
+    mock_client.undelete_page.return_value = {
+        "title": "Test Page",
+        "reason": "Complete restoration",
+        "revisions": 3,
+        "fileversions": 0
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Complete restoration",
+        "undeletetalk": True
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'Test Page'" in result[0].text
+    mock_client.undelete_page.assert_called_once_with(
+        title="Test Page",
+        reason="Complete restoration",
+        undeletetalk=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_with_tags(mock_client):
+    """Test page undelete with tags."""
+    mock_client.undelete_page.return_value = {
+        "title": "Test Page",
+        "reason": "Tagged restoration",
+        "revisions": 1,
+        "fileversions": 0
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Tagged restoration",
+        "tags": ["test-tag", "restoration"]
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'Test Page'" in result[0].text
+    mock_client.undelete_page.assert_called_once_with(
+        title="Test Page",
+        reason="Tagged restoration",
+        tags=["test-tag", "restoration"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_missing_title(mock_client):
+    """Test undelete with missing title."""
+    arguments = {}
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Error: 'title' parameter is required" in result[0].text
+    mock_client.undelete_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_empty_title(mock_client):
+    """Test undelete with empty title."""
+    arguments = {"title": ""}
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Error: 'title' parameter is required" in result[0].text
+    mock_client.undelete_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_none_title(mock_client):
+    """Test undelete with None title."""
+    arguments = {"title": None}
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Error: 'title' parameter is required" in result[0].text
+    mock_client.undelete_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_api_error(mock_client):
+    """Test undelete with API error."""
+    mock_client.undelete_page.side_effect = Exception("API Error: Permission denied")
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Test restoration"
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Error undeleting page: API Error: Permission denied" in result[0].text
+    mock_client.undelete_page.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_bad_response(mock_client):
+    """Test undelete with bad API response."""
+    # Mock response without expected structure
+    mock_client.undelete_page.return_value = {
+        "error": {
+            "code": "cantundelete",
+            "info": "Couldn't undelete: the requested revisions may not exist"
+        }
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Test restoration"
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Undelete failed:" in result[0].text
+    mock_client.undelete_page.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_undelete_page_with_watchlist(mock_client):
+    """Test page undelete with watchlist settings."""
+    mock_client.undelete_page.return_value = {
+        "title": "Test Page",
+        "reason": "Watched restoration",
+        "revisions": 1,
+        "fileversions": 0
+    }
+
+    arguments = {
+        "title": "Test Page",
+        "reason": "Watched restoration",
+        "watchlist": "watch",
+        "watchlistexpiry": "1 month"
+    }
+
+    result = await handle_undelete_page(mock_client, arguments)
+
+    assert len(result) == 1
+    assert "Successfully undeleted page 'Test Page'" in result[0].text
+    mock_client.undelete_page.assert_called_once_with(
+        title="Test Page",
+        reason="Watched restoration",
+        watchlist="watch",
+        watchlistexpiry="1 month"
+    )


### PR DESCRIPTION
Implement the `wiki_page_undelete` MCP tool according to the MediaWiki API:Undelete specification

```git-revs
e922151  (Base revision)
a66577b  Add undelete_page method to MediaWikiClient
22415ea  Create wiki_page_undelete handler
64ee197  Add handle_undelete_page import to handlers package
eec0fbc  Add wiki_page_undelete tool to server
7c33288  Create tests for wiki_page_undelete functionality
47e7444  Create documentation for wiki_page_undelete tool
HEAD     Fix handler to only pass non-default parameters
```

codemcp-id: 27-feat-implement-wiki-page-undelete-mcp-tool

---

## Executive Summary: `wiki_page_undelete` MCP Tool Testing

### Testing Scope
I conducted comprehensive testing of the `wiki_page_undelete` tool by creating test pages with multiple revisions and talk pages, deleting them, and then testing various undelete scenarios.

### Test Results

**✅ Successful Tests:**

1. **Basic Undelete** - Successfully restored a deleted page using only the required `title` parameter and optional `reason`

2. **Talk Page Restoration** - The `undeletetalk=true` parameter successfully restored both the main page and its associated talk page (restored 3 revisions total)

3. **Selective Timestamp Restoration** - The `timestamps` parameter correctly restored only specific revisions based on timestamp, allowing granular control over which version to restore

4. **Watchlist Management** - The `watchlist="watch"` parameter successfully added the restored page to the watchlist

5. **Watchlist Expiry** - The `watchlistexpiry` parameter correctly set an expiration date for watchlist monitoring

**❌ Failed Tests:**

1. **Tags Parameter** - Custom tags (`testing|undelete-test`) were rejected as "not allowed to be manually applied," indicating the wiki has restrictions on manual tag application

**🔧 Key Findings:**

- The tool restores all revisions by default when no `timestamps` parameter is specified
- The `undeletetalk` parameter is essential for restoring associated talk pages
- Tag restrictions depend on wiki configuration and may limit the `tags` parameter usage
- The tool provides clear feedback on the number of revisions and file versions restored
- Selective restoration via `timestamps` allows precise control over which content versions to recover

### Recommendation
The `wiki_page_undelete` tool is fully functional and reliable for page restoration. Users should be aware that tag usage may be restricted and should test timestamp-based selective restoration when only specific revisions need to be recovered.