### PR TITLE
feat: implement `wiki_meta_siteinfo` MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The server provides various MCP tools with the `wiki_` prefix:
 |[**`wiki_page_undelete`**](docs/tools/wiki_page_undelete.md)|Undelete (restore) deleted MediaWiki pages with comprehensive restoration options|
 |[**`wiki_search`**](docs/tools/wiki_search.md)|Search for pages using MediaWiki's search API with advanced filtering|
 |[**`wiki_opensearch`**](docs/tools/wiki_opensearch.md)|Search using OpenSearch protocol for quick suggestions and autocomplete|
+|[**`wiki_meta_siteinfo`**](docs/tools/wiki_meta_siteinfo.md)|Get overall site information including general info, namespaces, statistics, extensions, and more|
 
 ## Installation
 

--- a/docs/tools/wiki_meta_siteinfo.md
+++ b/docs/tools/wiki_meta_siteinfo.md
@@ -1,0 +1,117 @@
+# wiki_meta_siteinfo
+
+Get overall site information from MediaWiki.
+
+This tool corresponds to the MediaWiki API:Siteinfo endpoint and allows retrieving comprehensive information about the MediaWiki installation.
+
+## Parameters
+
+### siprop (list[str], optional)
+Which information to get. Default: ["general"]
+
+Available options:
+- **general**: Overall system information
+- **namespaces**: List of registered namespaces and their canonical names
+- **namespacealiases**: List of registered namespace aliases
+- **specialpagealiases**: List of special page aliases
+- **magicwords**: List of magic words and their aliases
+- **interwikimap**: Returns interwiki map (optionally filtered, optionally localised)
+- **dbrepllag**: Returns database server with the highest replication lag
+- **statistics**: Returns site statistics
+- **usergroups**: Returns user groups and the associated permissions
+- **autocreatetempuser**: Returns configuration for automatic creation of temporary user accounts
+- **clientlibraries**: Returns client-side libraries installed on the wiki
+- **libraries**: Returns libraries installed on the wiki
+- **extensions**: Returns extensions installed on the wiki
+- **fileextensions**: Returns list of file extensions allowed to be uploaded
+- **rightsinfo**: Returns wiki rights (license) information if available
+- **restrictions**: Returns information on available restriction (protection) types
+- **languages**: Returns a list of languages MediaWiki supports
+- **languagevariants**: Returns a list of language codes for which LanguageConverter is enabled
+- **skins**: Returns a list of all enabled skins
+- **extensiontags**: Returns a list of parser extension tags
+- **functionhooks**: Returns a list of parser function hooks
+- **showhooks**: Returns a list of all subscribed hooks
+- **variables**: Returns a list of variable IDs
+- **protocols**: Returns a list of protocols that are allowed in external links
+- **defaultoptions**: Returns the default values for user preferences
+- **uploaddialog**: Returns the upload dialog configuration
+- **autopromote**: Returns the automatic promotion configuration
+- **autopromoteonce**: Returns the automatic promotion configuration that are only done once
+- **copyuploaddomains**: Returns the list of allowed copy upload domains
+
+### sifilteriw (str, optional)
+Return only local or only nonlocal entries of the interwiki map.
+- **"local"**: Return only local interwiki entries
+- **"!local"**: Return only non-local interwiki entries
+
+### sishowalldb (bool, optional)
+List all database servers, not just the one lagging the most. Default: false
+
+### sinumberingroup (bool, optional)
+Lists the number of users in user groups. Default: false
+
+### siinlanguagecode (str, optional)
+Language code for localised language names (best effort) and skin names.
+
+## Examples
+
+### Get general site information
+```
+siprop: ["general"]
+```
+
+### Get namespaces and statistics
+```
+siprop: ["namespaces", "statistics"]
+```
+
+### Get all installed extensions and libraries
+```
+siprop: ["extensions", "libraries", "clientlibraries"]
+```
+
+### Get user groups with member counts
+```
+siprop: ["usergroups"]
+sinumberingroup: true
+```
+
+### Get local interwiki entries in German
+```
+siprop: ["interwikimap"]
+sifilteriw: "local"
+siinlanguagecode: "de"
+```
+
+### Get complete database replication information
+```
+siprop: ["dbrepllag"]
+sishowalldb: true
+```
+
+## Response Format
+
+The tool returns formatted text with sections for each type of information requested. The response includes:
+
+- **General Information**: Site name, version, URLs, database info, language settings
+- **Namespaces**: List of all namespaces with IDs and names
+- **Statistics**: Page counts, user counts, edit counts
+- **User Groups**: Available user groups and their permissions
+- **Extensions**: Installed extensions and their versions
+- **And more** depending on the siprop values requested
+
+## MediaWiki API Reference
+
+This tool implements the MediaWiki API:Siteinfo endpoint:
+https://www.mediawiki.org/wiki/Special:MyLanguage/API:Siteinfo
+
+## Error Handling
+
+The tool handles various error conditions:
+- Invalid siprop values (filtered out automatically)
+- Network connectivity issues
+- Authentication problems
+- Malformed responses
+
+Errors are returned as descriptive text explaining what went wrong.

--- a/mediawiki_api_mcp/client.py
+++ b/mediawiki_api_mcp/client.py
@@ -789,3 +789,79 @@ class MediaWikiClient:
         except Exception as e:
             logger.error(f"Undelete request failed: {e}")
             raise
+
+    async def get_siteinfo(
+        self,
+        siprop: list[str] | None = None,
+        sifilteriw: str | None = None,
+        sishowalldb: bool = False,
+        sinumberingroup: bool = False,
+        siinlanguagecode: str | None = None,
+        **kwargs: Any
+    ) -> dict[str, Any]:
+        """
+        Get overall site information from MediaWiki.
+
+        Args:
+            siprop: Which information to get (default: ["general"])
+            sifilteriw: Return only local or only nonlocal entries of interwiki map ("local" or "!local")
+            sishowalldb: List all database servers, not just the one lagging the most
+            sinumberingroup: Lists the number of users in user groups
+            siinlanguagecode: Language code for localised language names and skin names
+            **kwargs: Additional parameters
+
+        Returns:
+            API response dictionary containing site information
+        """
+        # Build siteinfo parameters
+        params = {
+            "action": "query",
+            "meta": "siteinfo",
+            "format": "json"
+        }
+
+        # Set which information to get (default to general)
+        if siprop is None:
+            siprop = ["general"]
+
+        # Validate siprop values
+        valid_props = [
+            "general", "namespaces", "namespacealiases", "specialpagealiases",
+            "magicwords", "interwikimap", "dbrepllag", "statistics", "usergroups",
+            "autocreatetempuser", "clientlibraries", "libraries", "extensions",
+            "fileextensions", "rightsinfo", "restrictions", "languages",
+            "languagevariants", "skins", "extensiontags", "functionhooks",
+            "showhooks", "variables", "protocols", "defaultoptions",
+            "uploaddialog", "autopromote", "autopromoteonce", "copyuploaddomains"
+        ]
+
+        filtered_props = [p for p in siprop if p in valid_props]
+        if filtered_props:
+            params["siprop"] = "|".join(filtered_props)
+
+        # Set interwiki filter
+        if sifilteriw and sifilteriw in ["local", "!local"]:
+            params["sifilteriw"] = sifilteriw
+
+        # Set boolean parameters
+        if sishowalldb:
+            params["sishowalldb"] = "1"
+
+        if sinumberingroup:
+            params["sinumberingroup"] = "1"
+
+        # Set language code
+        if siinlanguagecode:
+            params["siinlanguagecode"] = siinlanguagecode
+
+        # Add any additional parameters
+        params.update(kwargs)
+
+        try:
+            response = await self._make_request("GET", params=params)
+            logger.info("Siteinfo query completed successfully")
+            return response
+
+        except Exception as e:
+            logger.error(f"Siteinfo request failed: {e}")
+            raise

--- a/mediawiki_api_mcp/handlers/__init__.py
+++ b/mediawiki_api_mcp/handlers/__init__.py
@@ -1,5 +1,6 @@
 """MediaWiki MCP handlers package."""
 
+from .wiki_meta_siteinfo import handle_meta_siteinfo
 from .wiki_opensearch import handle_opensearch
 from .wiki_page_delete import handle_delete_page
 from .wiki_page_edit import handle_edit_page
@@ -8,4 +9,4 @@ from .wiki_page_move import handle_move_page
 from .wiki_page_undelete import handle_undelete_page
 from .wiki_search import handle_search
 
-__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page", "handle_undelete_page"]
+__all__ = ["handle_edit_page", "handle_get_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page", "handle_undelete_page", "handle_meta_siteinfo"]

--- a/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
+++ b/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
@@ -99,7 +99,7 @@ def format_siteinfo_section(section_name: str, data: Any) -> str:
         for field, label in key_fields:
             if field in data:
                 value = data[field]
-                if isinstance(value, (list, dict)):
+                if isinstance(value, list | dict):
                     value = json.dumps(value, indent=2)
                 output += f"  {label}: {value}\n"
 
@@ -239,7 +239,7 @@ def format_siteinfo_section(section_name: str, data: Any) -> str:
 
         if isinstance(data, dict):
             for key, value in data.items():
-                if isinstance(value, (list, dict)):
+                if isinstance(value, list | dict):
                     value = json.dumps(value, indent=2)
                 output += f"  {key}: {value}\n"
         elif isinstance(data, list):

--- a/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
+++ b/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
@@ -187,18 +187,35 @@ def format_siteinfo_section(section_name: str, data: Any) -> str:
         output += "Skins:\n"
         output += "-" * 6 + "\n"
 
-        for skin_key, skin_data in data.items():
-            if isinstance(skin_data, dict):
-                name = skin_data.get("*", skin_key)
-                output += f"  {name}\n"
+        if isinstance(data, list):
+            # Handle as list of skin objects
+            for skin in data:
+                if isinstance(skin, dict):
+                    name = skin.get("*", skin.get("code", ""))
+                    output += f"  {name}\n"
+        elif isinstance(data, dict):
+            # Handle as dictionary (legacy format)
+            for skin_key, skin_data in data.items():
+                if isinstance(skin_data, dict):
+                    name = skin_data.get("*", skin_key)
+                    output += f"  {name}\n"
 
     elif section_name == "languages":
         output += "Supported Languages:\n"
         output += "-" * 20 + "\n"
 
-        for lang_code, lang_name in data.items():
-            if isinstance(lang_name, str):
-                output += f"  {lang_code}: {lang_name}\n"
+        if isinstance(data, list):
+            # Handle as list of language objects
+            for lang in data:
+                if isinstance(lang, dict):
+                    code = lang.get("code", "")
+                    name = lang.get("*", code)
+                    output += f"  {code}: {name}\n"
+        elif isinstance(data, dict):
+            # Handle as dictionary (legacy format)
+            for lang_code, lang_name in data.items():
+                if isinstance(lang_name, str):
+                    output += f"  {lang_code}: {lang_name}\n"
 
     elif section_name == "interwikimap":
         output += "Interwiki Map:\n"

--- a/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
+++ b/mediawiki_api_mcp/handlers/wiki_meta_siteinfo.py
@@ -1,0 +1,261 @@
+"""MediaWiki siteinfo metadata handlers for MCP server."""
+
+import json
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import mcp.types as types
+
+from ..client import MediaWikiClient
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_meta_siteinfo(
+    client: MediaWikiClient,
+    arguments: dict[str, Any]
+) -> Sequence[types.TextContent]:
+    """Handle wiki_meta_siteinfo tool calls for getting site information."""
+
+    # Extract siteinfo parameters
+    siprop = arguments.get("siprop")
+    sifilteriw = arguments.get("sifilteriw")
+    sishowalldb = arguments.get("sishowalldb", False)
+    sinumberingroup = arguments.get("sinumberingroup", False)
+    siinlanguagecode = arguments.get("siinlanguagecode")
+
+    try:
+        result = await client.get_siteinfo(
+            siprop=siprop,
+            sifilteriw=sifilteriw,
+            sishowalldb=sishowalldb,
+            sinumberingroup=sinumberingroup,
+            siinlanguagecode=siinlanguagecode
+        )
+
+        if "query" not in result:
+            return [types.TextContent(
+                type="text",
+                text=f"Unexpected response format: {result}"
+            )]
+
+        query_data = result["query"]
+
+        # Format the response based on what information was requested
+        response_text = "MediaWiki Site Information\n"
+        response_text += "=" * 29 + "\n\n"
+
+        # Process each type of information
+        for info_type, info_data in query_data.items():
+            response_text += format_siteinfo_section(info_type, info_data)
+            response_text += "\n"
+
+        return [types.TextContent(
+            type="text",
+            text=response_text
+        )]
+
+    except Exception as e:
+        return [types.TextContent(
+            type="text",
+            text=f"Error getting site information: {str(e)}"
+        )]
+
+
+def format_siteinfo_section(section_name: str, data: Any) -> str:
+    """Format a specific section of site information."""
+    output = ""
+
+    if section_name == "general":
+        output += "General Information:\n"
+        output += "-" * 21 + "\n"
+
+        # Key general information
+        key_fields = [
+            ("sitename", "Site name"),
+            ("mainpage", "Main page"),
+            ("base", "Base URL"),
+            ("server", "Server"),
+            ("wikiid", "Wiki ID"),
+            ("generator", "MediaWiki version"),
+            ("phpversion", "PHP version"),
+            ("dbtype", "Database type"),
+            ("dbversion", "Database version"),
+            ("lang", "Language"),
+            ("fallback", "Language fallback"),
+            ("legaltitlechars", "Legal title characters"),
+            ("case", "Case sensitivity"),
+            ("timezone", "Timezone"),
+            ("timeoffset", "Time offset"),
+            ("articlepath", "Article path"),
+            ("scriptpath", "Script path"),
+            ("script", "Script"),
+            ("variantarticlepath", "Variant article path"),
+            ("favicon", "Favicon"),
+            ("logo", "Logo"),
+        ]
+
+        for field, label in key_fields:
+            if field in data:
+                value = data[field]
+                if isinstance(value, (list, dict)):
+                    value = json.dumps(value, indent=2)
+                output += f"  {label}: {value}\n"
+
+        # Rights information
+        if "rights" in data:
+            output += f"  Rights: {data['rights']}\n"
+        if "rightsurl" in data:
+            output += f"  Rights URL: {data['rightsurl']}\n"
+
+    elif section_name == "namespaces":
+        output += "Namespaces:\n"
+        output += "-" * 11 + "\n"
+
+        for ns_id, ns_data in data.items():
+            if isinstance(ns_data, dict):
+                name = ns_data.get("*", f"Namespace {ns_id}")
+                canonical = ns_data.get("canonical", "")
+                case = ns_data.get("case", "")
+
+                output += f"  {ns_id}: {name}"
+                if canonical and canonical != name:
+                    output += f" (canonical: {canonical})"
+                if case:
+                    output += f" [{case}]"
+                output += "\n"
+
+    elif section_name == "namespacealiases":
+        output += "Namespace Aliases:\n"
+        output += "-" * 18 + "\n"
+
+        for alias in data:
+            if isinstance(alias, dict):
+                alias_name = alias.get("*", "")
+                ns_id = alias.get("id", "")
+                output += f"  {alias_name} -> Namespace {ns_id}\n"
+
+    elif section_name == "statistics":
+        output += "Site Statistics:\n"
+        output += "-" * 16 + "\n"
+
+        stats_fields = [
+            ("pages", "Total pages"),
+            ("articles", "Content pages"),
+            ("edits", "Total edits"),
+            ("images", "Uploaded files"),
+            ("users", "Registered users"),
+            ("activeusers", "Active users"),
+            ("admins", "Administrators"),
+            ("jobs", "Job queue length"),
+        ]
+
+        for field, label in stats_fields:
+            if field in data:
+                output += f"  {label}: {data[field]:,}\n"
+
+    elif section_name == "usergroups":
+        output += "User Groups:\n"
+        output += "-" * 12 + "\n"
+
+        for group in data:
+            if isinstance(group, dict):
+                name = group.get("name", "")
+                rights = group.get("rights", [])
+                output += f"  {name}:\n"
+                if rights:
+                    output += f"    Rights: {', '.join(rights[:5])}"
+                    if len(rights) > 5:
+                        output += f" (and {len(rights) - 5} more)"
+                    output += "\n"
+
+    elif section_name == "extensions":
+        output += "Extensions:\n"
+        output += "-" * 11 + "\n"
+
+        for ext in data:
+            if isinstance(ext, dict):
+                name = ext.get("name", "")
+                version = ext.get("version", "")
+                output += f"  {name}"
+                if version:
+                    output += f" (v{version})"
+                output += "\n"
+
+    elif section_name == "skins":
+        output += "Skins:\n"
+        output += "-" * 6 + "\n"
+
+        for skin_key, skin_data in data.items():
+            if isinstance(skin_data, dict):
+                name = skin_data.get("*", skin_key)
+                output += f"  {name}\n"
+
+    elif section_name == "languages":
+        output += "Supported Languages:\n"
+        output += "-" * 20 + "\n"
+
+        for lang_code, lang_name in data.items():
+            if isinstance(lang_name, str):
+                output += f"  {lang_code}: {lang_name}\n"
+
+    elif section_name == "interwikimap":
+        output += "Interwiki Map:\n"
+        output += "-" * 14 + "\n"
+
+        for iw in data:
+            if isinstance(iw, dict):
+                prefix = iw.get("prefix", "")
+                url = iw.get("url", "")
+                local = " (local)" if iw.get("local") else ""
+                output += f"  {prefix}: {url}{local}\n"
+
+    elif section_name == "dbrepllag":
+        output += "Database Replication Lag:\n"
+        output += "-" * 26 + "\n"
+
+        for db in data:
+            if isinstance(db, dict):
+                host = db.get("host", "")
+                lag = db.get("lag", "")
+                output += f"  {host}: {lag} seconds\n"
+
+    elif section_name == "fileextensions":
+        output += "Allowed File Extensions:\n"
+        output += "-" * 25 + "\n"
+
+        extensions = [ext.get("ext", "") for ext in data if isinstance(ext, dict)]
+        # Group extensions for better readability
+        for i in range(0, len(extensions), 10):
+            group = extensions[i:i+10]
+            output += f"  {', '.join(group)}\n"
+
+    else:
+        # Generic formatting for other sections
+        section_title = section_name.replace("_", " ").title()
+        output += f"{section_title}:\n"
+        output += "-" * len(section_title) + "\n"
+
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if isinstance(value, (list, dict)):
+                    value = json.dumps(value, indent=2)
+                output += f"  {key}: {value}\n"
+        elif isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    # Try to find a meaningful field to display
+                    display_value = (
+                        item.get("name") or
+                        item.get("*") or
+                        item.get("title") or
+                        str(item)
+                    )
+                    output += f"  {display_value}\n"
+                else:
+                    output += f"  {item}\n"
+        else:
+            output += f"  {data}\n"
+
+    return output

--- a/mediawiki_api_mcp/server.py
+++ b/mediawiki_api_mcp/server.py
@@ -405,6 +405,51 @@ async def wiki_page_undelete(
         return f"Error: {str(e)}"
 
 
+@mcp.tool()
+async def wiki_meta_siteinfo(
+    siprop: list[str] | None = None,
+    sifilteriw: str = "",
+    sishowalldb: bool = False,
+    sinumberingroup: bool = False,
+    siinlanguagecode: str = "",
+) -> str:
+    """Get overall site information from MediaWiki.
+
+    Args:
+        siprop: Which information to get (options: general, namespaces, namespacealiases,
+                specialpagealiases, magicwords, interwikimap, dbrepllag, statistics, usergroups,
+                autocreatetempuser, clientlibraries, libraries, extensions, fileextensions,
+                rightsinfo, restrictions, languages, languagevariants, skins, extensiontags,
+                functionhooks, showhooks, variables, protocols, defaultoptions, uploaddialog,
+                autopromote, autopromoteonce, copyuploaddomains). Default: ["general"]
+        sifilteriw: Return only local or only nonlocal entries of interwiki map ("local" or "!local")
+        sishowalldb: List all database servers, not just the one lagging the most
+        sinumberingroup: Lists the number of users in user groups
+        siinlanguagecode: Language code for localised language names and skin names
+    """
+    try:
+        config = get_config()
+        async with MediaWikiClient(config) as client:
+            # Import here to avoid circular imports
+            from .handlers import handle_meta_siteinfo
+
+            # Convert FastMCP parameters to handler arguments
+            arguments = {
+                "siprop": siprop,
+                "sifilteriw": sifilteriw if sifilteriw else None,
+                "sishowalldb": sishowalldb,
+                "sinumberingroup": sinumberingroup,
+                "siinlanguagecode": siinlanguagecode if siinlanguagecode else None,
+            }
+
+            result = await handle_meta_siteinfo(client, arguments)
+            # Return the formatted text from the handler
+            return result[0].text if result else "No results"
+    except Exception as e:
+        logger.error(f"Wiki meta siteinfo failed: {e}")
+        return f"Error: {str(e)}"
+
+
 def run_server() -> None:
     """Synchronous entry point for the MCP server."""
     mcp.run(transport='stdio')

--- a/tests/test_wiki_meta_siteinfo.py
+++ b/tests/test_wiki_meta_siteinfo.py
@@ -282,3 +282,142 @@ async def test_handle_meta_siteinfo_file_extensions():
     assert "png" in result[0].text
     assert "jpg" in result[0].text
     assert "pdf" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_languages():
+    """Test getting languages information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "languages": [
+                {"code": "en", "*": "English"},
+                {"code": "es", "*": "español"},
+                {"code": "fr", "*": "français"},
+                {"code": "de", "*": "Deutsch"}
+            ]
+        }
+    }
+
+    arguments = {"siprop": ["languages"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Supported Languages" in result[0].text
+    assert "en: English" in result[0].text
+    assert "es: español" in result[0].text
+    assert "fr: français" in result[0].text
+    assert "de: Deutsch" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_skins():
+    """Test getting skins information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "skins": [
+                {"code": "vector", "*": "Vector"},
+                {"code": "monobook", "*": "MonoBook"},
+                {"code": "timeless", "*": "Timeless"},
+                {"code": "modern", "*": "Modern"}
+            ]
+        }
+    }
+
+    arguments = {"siprop": ["skins"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Skins" in result[0].text
+    assert "Vector" in result[0].text
+    assert "MonoBook" in result[0].text
+    assert "Timeless" in result[0].text
+    assert "Modern" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_languages_legacy_format():
+    """Test getting languages information in legacy dictionary format."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "languages": {
+                "en": "English",
+                "es": "español",
+                "fr": "français"
+            }
+        }
+    }
+
+    arguments = {"siprop": ["languages"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Supported Languages" in result[0].text
+    assert "en: English" in result[0].text
+    assert "es: español" in result[0].text
+    assert "fr: français" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_skins_legacy_format():
+    """Test getting skins information in legacy dictionary format."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "skins": {
+                "vector": {"*": "Vector"},
+                "monobook": {"*": "MonoBook"},
+                "timeless": {"*": "Timeless"}
+            }
+        }
+    }
+
+    arguments = {"siprop": ["skins"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Skins" in result[0].text
+    assert "Vector" in result[0].text
+    assert "MonoBook" in result[0].text
+    assert "Timeless" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_combined_props():
+    """Test getting multiple types including languages and skins."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "general": {
+                "sitename": "Test Wiki",
+                "generator": "MediaWiki 1.39.0"
+            },
+            "languages": [
+                {"code": "en", "*": "English"},
+                {"code": "es", "*": "español"}
+            ],
+            "skins": [
+                {"code": "vector", "*": "Vector"},
+                {"code": "monobook", "*": "MonoBook"}
+            ]
+        }
+    }
+
+    arguments = {"siprop": ["general", "languages", "skins"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "General Information" in result[0].text
+    assert "Supported Languages" in result[0].text
+    assert "Skins" in result[0].text
+    assert "Test Wiki" in result[0].text
+    assert "en: English" in result[0].text
+    assert "Vector" in result[0].text
+

--- a/tests/test_wiki_meta_siteinfo.py
+++ b/tests/test_wiki_meta_siteinfo.py
@@ -1,7 +1,8 @@
 """Tests for wiki_meta_siteinfo tool."""
 
+from unittest.mock import AsyncMock
+
 import pytest
-from unittest.mock import AsyncMock, patch
 
 from mediawiki_api_mcp.handlers.wiki_meta_siteinfo import handle_meta_siteinfo
 

--- a/tests/test_wiki_meta_siteinfo.py
+++ b/tests/test_wiki_meta_siteinfo.py
@@ -1,0 +1,283 @@
+"""Tests for wiki_meta_siteinfo tool."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mediawiki_api_mcp.handlers.wiki_meta_siteinfo import handle_meta_siteinfo
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_general():
+    """Test getting general site information."""
+    # Mock client and response
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "general": {
+                "sitename": "Test Wiki",
+                "mainpage": "Main Page",
+                "base": "https://example.com/wiki/Main_Page",
+                "server": "https://example.com",
+                "wikiid": "testwiki",
+                "generator": "MediaWiki 1.39.0",
+                "lang": "en",
+                "case": "first-letter",
+                "timezone": "UTC",
+                "timeoffset": 0
+            }
+        }
+    }
+
+    arguments = {"siprop": ["general"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Test Wiki" in result[0].text
+    assert "MediaWiki 1.39.0" in result[0].text
+    assert "General Information" in result[0].text
+
+    # Verify the client was called with correct parameters
+    mock_client.get_siteinfo.assert_called_once_with(
+        siprop=["general"],
+        sifilteriw=None,
+        sishowalldb=False,
+        sinumberingroup=False,
+        siinlanguagecode=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_namespaces():
+    """Test getting namespace information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "namespaces": {
+                "0": {"*": "", "case": "first-letter"},
+                "1": {"*": "Talk", "case": "first-letter"},
+                "2": {"*": "User", "case": "first-letter"},
+                "3": {"*": "User talk", "case": "first-letter"}
+            }
+        }
+    }
+
+    arguments = {"siprop": ["namespaces"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Namespaces" in result[0].text
+    assert "Talk" in result[0].text
+    assert "User" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_statistics():
+    """Test getting site statistics."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "statistics": {
+                "pages": 12345,
+                "articles": 5678,
+                "edits": 98765,
+                "images": 432,
+                "users": 1234,
+                "activeusers": 56,
+                "admins": 3
+            }
+        }
+    }
+
+    arguments = {"siprop": ["statistics"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Site Statistics" in result[0].text
+    assert "12,345" in result[0].text  # Check number formatting
+    assert "Content pages: 5,678" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_multiple_props():
+    """Test getting multiple types of site information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "general": {
+                "sitename": "Test Wiki",
+                "generator": "MediaWiki 1.39.0"
+            },
+            "statistics": {
+                "pages": 1000,
+                "articles": 500
+            }
+        }
+    }
+
+    arguments = {"siprop": ["general", "statistics"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "General Information" in result[0].text
+    assert "Site Statistics" in result[0].text
+    assert "Test Wiki" in result[0].text
+    assert "1,000" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_with_options():
+    """Test getting site information with additional options."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "usergroups": [
+                {
+                    "name": "sysop",
+                    "rights": ["delete", "undelete", "protect", "block"]
+                },
+                {
+                    "name": "user",
+                    "rights": ["read", "edit", "createpage"]
+                }
+            ]
+        }
+    }
+
+    arguments = {
+        "siprop": ["usergroups"],
+        "sinumberingroup": True,
+        "siinlanguagecode": "en"
+    }
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "User Groups" in result[0].text
+    assert "sysop" in result[0].text
+    assert "delete" in result[0].text
+
+    # Verify the client was called with correct parameters
+    mock_client.get_siteinfo.assert_called_once_with(
+        siprop=["usergroups"],
+        sifilteriw=None,
+        sishowalldb=False,
+        sinumberingroup=True,
+        siinlanguagecode="en"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_interwiki_filter():
+    """Test getting interwiki information with filter."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "interwikimap": [
+                {"prefix": "enwiki", "url": "https://en.wikipedia.org/wiki/$1", "local": True},
+                {"prefix": "commons", "url": "https://commons.wikimedia.org/wiki/$1", "local": False}
+            ]
+        }
+    }
+
+    arguments = {
+        "siprop": ["interwikimap"],
+        "sifilteriw": "local"
+    }
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Interwiki Map" in result[0].text
+    assert "enwiki" in result[0].text
+
+    # Verify the client was called with correct parameters
+    mock_client.get_siteinfo.assert_called_once_with(
+        siprop=["interwikimap"],
+        sifilteriw="local",
+        sishowalldb=False,
+        sinumberingroup=False,
+        siinlanguagecode=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_error_response():
+    """Test handling of unexpected response format."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {"error": "Invalid request"}
+
+    arguments = {"siprop": ["general"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Unexpected response format" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_client_exception():
+    """Test handling of client exceptions."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.side_effect = Exception("Network error")
+
+    arguments = {"siprop": ["general"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Error getting site information" in result[0].text
+    assert "Network error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_extensions():
+    """Test getting extensions information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "extensions": [
+                {"name": "ParserFunctions", "version": "1.6.0"},
+                {"name": "Cite", "version": "1.0.0"},
+                {"name": "VisualEditor"}
+            ]
+        }
+    }
+
+    arguments = {"siprop": ["extensions"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Extensions" in result[0].text
+    assert "ParserFunctions (v1.6.0)" in result[0].text
+    assert "Cite (v1.0.0)" in result[0].text
+    assert "VisualEditor" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_meta_siteinfo_file_extensions():
+    """Test getting file extensions information."""
+    mock_client = AsyncMock()
+    mock_client.get_siteinfo.return_value = {
+        "query": {
+            "fileextensions": [
+                {"ext": "png"}, {"ext": "gif"}, {"ext": "jpg"}, {"ext": "jpeg"},
+                {"ext": "webp"}, {"ext": "svg"}, {"ext": "pdf"}, {"ext": "ogg"},
+                {"ext": "oga"}, {"ext": "ogv"}, {"ext": "webm"}, {"ext": "mp4"}
+            ]
+        }
+    }
+
+    arguments = {"siprop": ["fileextensions"]}
+    result = await handle_meta_siteinfo(mock_client, arguments)
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "Allowed File Extensions" in result[0].text
+    assert "png" in result[0].text
+    assert "jpg" in result[0].text
+    assert "pdf" in result[0].text


### PR DESCRIPTION
Implement the `wiki_meta_siteinfo` MCP tool according to the MediaWiki API:Siteinfo specification.

```git-revs
407416b  (Base revision)
304aa76  Add siteinfo method to MediaWikiClient for getting site information
aa014c6  Create handler for wiki_meta_siteinfo tool
775f054  Add wiki_meta_siteinfo handler to __init__.py
337192d  Add wiki_meta_siteinfo tool to the MCP server
a6cbd48  Create documentation for wiki_meta_siteinfo tool
9a82869  Create tests for wiki_meta_siteinfo tool
HEAD     Update README to include wiki_meta_siteinfo tool
```

codemcp-id: 28-feat-implement-mediawiki-api-mcp-server-with-wiki-

---

## Complete Test Results Summary

Here are the comprehensive test results for all available arguments of the `wiki_meta_siteinfo` tool:

### **Working `siprop` Parameters**
✅ **Successfully tested:**
- `general` - Basic wiki information, URLs, versions, configuration
- `namespaces` - All namespaces including custom ones
- `namespacealiases` - Image → File namespace aliases
- `specialpagealiases` - All special pages and their aliases
- `magicwords` - Parser functions and magic words (including SMW extensions)
- `interwikimap` - External wiki link prefixes
- `dbrepllag` - Database replication lag information
- `statistics` - Page counts, edits, users, file statistics
- `usergroups` - User groups and their rights (including SMW groups)
- `autocreatetempuser` - Temporary user creation settings (empty)
- `clientlibraries` - JavaScript libraries (Vue, jQuery, etc.)
- `libraries` - PHP dependencies (Composer packages)
- `extensions` - Installed extensions (including SemanticMediaWiki)
- `fileextensions` - Allowed upload file types (png, gif, jpg, jpeg, webp)
- `rightsinfo` - Copyright information (empty in test installation)
- `restrictions` - Protection levels and types
- `languagevariants` - Language variant fallbacks (Chinese, Serbian, etc.)
- `extensiontags` - Available XML tags (`<ref>`, `<math>`, `<smwdoc>`, etc.)
- `functionhooks` - Available parser functions (including SMW functions)
- `showhooks` - All available MediaWiki hooks (extensive list)
- `variables` - Available magic variables
- `protocols` - Allowed URL protocols (http, https, mailto, etc.)
- `defaultoptions` - Default user preferences (very comprehensive)
- `uploaddialog` - Upload form configuration
- `autopromote` - Auto-promotion conditions (autoconfirmed after 0 edits/days)
- `autopromoteonce` - One-time promotion conditions (empty)

❌ **Parameters that caused errors:**
- `languages` - Error: 'list' object has no attribute 'items'
- `skins` - Error: 'list' object has no attribute 'items'

❌ **Unrecognized parameter:**
- `copyuploaddomains` - Warning: Unrecognized value

### **Working Modifier Parameters**
✅ **Successfully tested:**
- `sinumberingroup=true` - Shows user counts in groups
- `sifilteriw="local"` - Filters interwiki map for local entries (empty result)
- `sifilteriw="!local"` - Filters interwiki map for non-local entries (shows all external links)
- `siinlanguagecode="fr"` - Language code for localization (works but minimal visible difference)
- `sishowalldb=true` - Tested with dbrepllag siprop and returned database information (requires `$wgShowHostnames=true`)

### **Key Observations**

1. **Rich Semantic MediaWiki Integration**: The installation has extensive SMW features with custom namespaces, user groups (smwadministrator, smwcurator, smweditor), and SMW-specific magic words and hooks.

2. **Modern MediaWiki Setup**: Running MediaWiki 1.43.1 with PHP 8.3.13 and MariaDB, includes modern extensions like VisualEditor, DiscussionTools, and Echo.

3. **Comprehensive Extension Support**: 30+ extensions installed including syntax highlighting, math rendering, multimedia viewer, and developer tools.

4. **Some API Limitations**: Two parameters (`languages`, `skins`) cause processing errors, and one parameter (`copyuploaddomains`) is not recognized in this MediaWiki version.

The tool provides extensive insight into MediaWiki installations and works reliably for most information categories. The modifier parameters allow for fine-tuned filtering and localization of results.