### PR TITLE
feat: implement `wiki_page_compare` MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The server provides various MCP tools with the `wiki_` prefix:
 |[**`wiki_page_edit`**](docs/tools/wiki_page_edit.md)|Edit or create MediaWiki pages with comprehensive editing options|
 |[**`wiki_page_get`**](docs/tools/wiki_page_get.md)|Retrieve page information and content|
 |[**`wiki_page_parse`**](docs/tools/wiki_page_parse.md)|Parse page content with support for wikitext processing, HTML generation, metadata extraction, and advanced parsing features|
+|[**`wiki_page_compare`**](docs/tools/wiki_page_compare.md)|Compare two revisions of MediaWiki pages or arbitrary content|
 |[**`wiki_page_move`**](docs/tools/wiki_page_move.md)|Move pages with support for talk pages, subpages, and redirects|
 |[**`wiki_page_delete`**](docs/tools/wiki_page_delete.md)|Delete pages with support for talk pages, watchlist management, and logging|
 |[**`wiki_page_undelete`**](docs/tools/wiki_page_undelete.md)|Undelete (restore) deleted MediaWiki pages with comprehensive restoration options|

--- a/docs/tools/wiki_page_compare.md
+++ b/docs/tools/wiki_page_compare.md
@@ -1,0 +1,123 @@
+### wiki_page_compare
+
+Compare two revisions of MediaWiki pages or arbitrary content using the Compare API. This tool creates diff output showing differences between specified content sources in various formats, supporting both revision comparison and custom content comparison.
+
+**Source Content Specification (From) Parameters:**
+- `fromtitle` (string): Title of the first page to compare
+- `fromid` (integer): Page ID of the first page to compare
+- `fromrev` (integer): Revision ID of the first content to compare
+
+**Target Content Specification (To) Parameters:**
+- `totitle` (string): Title of the second page to compare
+- `toid` (integer): Page ID of the second page to compare
+- `torev` (integer): Revision ID of the second content to compare
+
+**Slot Management Parameters:**
+- `fromslots` (string): Pipe-separated list of slots to modify on the 'from' side. Use templated slot parameters for slot-specific content
+- `toslots` (string): Pipe-separated list of slots to modify on the 'to' side. Use templated slot parameters for slot-specific content
+
+**Output Control Parameters:**
+- `prop` (string): Which pieces of information to return. Use '*' to specify all available values
+- `difftype` (string): Format of diff output. Options: 'inline', 'table', 'unified'
+
+**Slot-Specific Content Parameters (Main Slot):**
+- `fromtext_main` (string): Text content for the main slot on 'from' side
+- `totext_main` (string): Text content for the main slot on 'to' side
+- `fromcontentformat_main` (string): Content serialization format for main slot on 'from' side
+- `tocontentformat_main` (string): Content serialization format for main slot on 'to' side
+- `fromcontentmodel_main` (string): Content model for main slot on 'from' side (e.g., 'wikitext', 'json', 'css')
+- `tocontentmodel_main` (string): Content model for main slot on 'to' side
+- `fromsection_main` (string): Section identifier for main slot on 'from' side
+- `tosection_main` (string): Section identifier for main slot on 'to' side
+- `frompst_main` (boolean): Perform pre-save transform for main slot on 'from' side
+- `topst_main` (boolean): Perform pre-save transform for main slot on 'to' side
+
+**Legacy Parameters (Deprecated but Supported):**
+- `fromtext` (string): Text content for 'from' side (use `fromslots=main` and `fromtext_main` instead)
+- `totext` (string): Text content for 'to' side (use `toslots=main` and `totext_main` instead)
+- `fromcontentformat` (string): Content format for 'from' side (use `fromcontentformat_main` instead)
+- `tocontentformat` (string): Content format for 'to' side (use `tocontentformat_main` instead)
+- `fromcontentmodel` (string): Content model for 'from' side (use `fromcontentmodel_main` instead)
+- `tocontentmodel` (string): Content model for 'to' side (use `tocontentmodel_main` instead)
+- `tosection` (string): Section identifier for 'to' side (use slot-specific section parameters instead)
+
+**Supported Content Formats:**
+- `application/json`
+- `application/octet-stream`
+- `application/unknown`
+- `application/x-binary`
+- `text/css`
+- `text/javascript`
+- `text/plain`
+- `text/unknown`
+- `text/x-wiki`
+- `unknown/unknown`
+
+**Supported Content Models:**
+- `GadgetDefinition`
+- `JsonSchema`
+- `MassMessageListContent`
+- `NewsletterContent`
+- `Scribunto`
+- `SecurePoll`
+- `css`
+- `flow-board`
+- `javascript`
+- `json`
+- `sanitized-css`
+- `text`
+- `translate-messagebundle`
+- `unknown`
+- `wikitext`
+
+**Usage Examples:**
+
+**Compare Two Specific Revisions:**
+```
+fromrev: 12345
+torev: 12350
+difftype: table
+```
+
+**Compare Current Page Content with Modified Text:**
+```
+fromtitle: "Example Page"
+toslots: "main"
+totext_main: "Modified content"
+tocontentmodel_main: "wikitext"
+difftype: unified
+```
+
+**Compare Two Different Pages:**
+```
+fromtitle: "Page A"
+totitle: "Page B"
+prop: "*"
+difftype: inline
+```
+
+**Compare with Section Modification:**
+```
+fromtitle: "Documentation"
+toslots: "main"
+totext_main: "Updated section content"
+tosection_main: "2"
+tocontentmodel_main: "wikitext"
+```
+
+**Advanced Slot-Based Comparison:**
+```
+fromtitle: "Template:Example"
+toslots: "main"
+totext_main: "{{Updated template code}}"
+tocontentmodel_main: "wikitext"
+topst_main: true
+difftype: table
+```
+
+**Notes:**
+- At least one 'from' parameter (fromtitle, fromid, fromrev, fromtext, or fromslots) is required
+- At least one 'to' parameter (totitle, toid, torev, totext, or toslots) is required
+- Slot-based parameters take precedence over legacy parameters when both are provided
+- Content models should match the actual content type for accurate parsing
+- The tool returns formatted comparison output showing additions, deletions, and metadata

--- a/mediawiki_api_mcp/client.py
+++ b/mediawiki_api_mcp/client.py
@@ -75,6 +75,10 @@ class MediaWikiClient:
         """Undelete (restore) the revisions of a deleted MediaWiki page."""
         return await self.page_client.undelete_page(**kwargs)
 
+    async def compare_page(self, **kwargs: Any) -> dict[str, Any]:
+        """Compare two revisions of wiki pages or arbitrary content."""
+        return await self.page_client.compare_page(**kwargs)
+
     # Search operations delegation
     async def search_pages(self, **kwargs: Any) -> dict[str, Any]:
         """Perform a full-text search using MediaWiki's search API."""

--- a/mediawiki_api_mcp/client_modules/client_page.py
+++ b/mediawiki_api_mcp/client_modules/client_page.py
@@ -850,7 +850,7 @@ class MediaWikiPageClient:
             response = await self.auth_client._make_request("GET", params=params)
 
             if "compare" in response:
-                logger.info(f"Successfully compared content")
+                logger.info("Successfully compared content")
                 return response
             else:
                 logger.error(f"Compare failed: {response}")

--- a/mediawiki_api_mcp/handlers/__init__.py
+++ b/mediawiki_api_mcp/handlers/__init__.py
@@ -2,6 +2,7 @@
 
 from .wiki_meta_siteinfo import handle_meta_siteinfo
 from .wiki_opensearch import handle_opensearch
+from .wiki_page_compare import handle_compare_page
 from .wiki_page_delete import handle_delete_page
 from .wiki_page_edit import handle_edit_page
 from .wiki_page_get import handle_get_page
@@ -10,4 +11,4 @@ from .wiki_page_parse import handle_parse_page
 from .wiki_page_undelete import handle_undelete_page
 from .wiki_search import handle_search
 
-__all__ = ["handle_edit_page", "handle_get_page", "handle_parse_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page", "handle_undelete_page", "handle_meta_siteinfo"]
+__all__ = ["handle_edit_page", "handle_get_page", "handle_parse_page", "handle_search", "handle_opensearch", "handle_move_page", "handle_delete_page", "handle_undelete_page", "handle_meta_siteinfo", "handle_compare_page"]

--- a/mediawiki_api_mcp/handlers/wiki_page_compare.py
+++ b/mediawiki_api_mcp/handlers/wiki_page_compare.py
@@ -1,0 +1,165 @@
+"""MediaWiki page comparison handlers for MCP server."""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import mcp.types as types
+
+from ..client import MediaWikiClient
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_compare_page(
+    client: MediaWikiClient,
+    arguments: dict[str, Any]
+) -> Sequence[types.TextContent]:
+    """Handle wiki_page_compare tool calls with support for MediaWiki Compare API."""
+    # Extract basic comparison parameters
+    fromtitle = arguments.get("fromtitle")
+    fromid = arguments.get("fromid")
+    fromrev = arguments.get("fromrev")
+    totitle = arguments.get("totitle")
+    toid = arguments.get("toid")
+    torev = arguments.get("torev")
+
+    # Extract slot and output parameters
+    fromslots = arguments.get("fromslots")
+    toslots = arguments.get("toslots")
+    prop = arguments.get("prop")
+    difftype = arguments.get("difftype")
+
+    # Extract legacy parameters
+    fromtext = arguments.get("fromtext")
+    totext = arguments.get("totext")
+    fromcontentformat = arguments.get("fromcontentformat")
+    tocontentformat = arguments.get("tocontentformat")
+    fromcontentmodel = arguments.get("fromcontentmodel")
+    tocontentmodel = arguments.get("tocontentmodel")
+    tosection = arguments.get("tosection")
+
+    # Extract slot-specific parameters
+    slot_params = {}
+    for key, value in arguments.items():
+        if (key.startswith(("fromtext-", "totext-", "fromcontentformat-", "tocontentformat-",
+                           "fromcontentmodel-", "tocontentmodel-", "fromsection-", "tosection-",
+                           "frompst-", "topst-")) and value is not None):
+            slot_params[key] = value
+
+    try:
+        result = await client.compare_page(
+            fromtitle=fromtitle,
+            fromid=fromid,
+            fromrev=fromrev,
+            totitle=totitle,
+            toid=toid,
+            torev=torev,
+            fromslots=fromslots,
+            toslots=toslots,
+            prop=prop,
+            difftype=difftype,
+            fromtext=fromtext,
+            totext=totext,
+            fromcontentformat=fromcontentformat,
+            tocontentformat=tocontentformat,
+            fromcontentmodel=fromcontentmodel,
+            tocontentmodel=tocontentmodel,
+            tosection=tosection,
+            slot_params=slot_params if slot_params else None
+        )
+
+        if "compare" not in result:
+            return [types.TextContent(
+                type="text",
+                text="Error: Unexpected response format from MediaWiki Compare API"
+            )]
+
+        return await _format_compare_result(result, arguments)
+
+    except Exception as e:
+        return [types.TextContent(
+            type="text",
+            text=f"Error comparing pages: {str(e)}"
+        )]
+
+
+async def _format_compare_result(
+    result: dict[str, Any],
+    arguments: dict[str, Any]
+) -> Sequence[types.TextContent]:
+    """Format the comparison result for display."""
+    compare_data = result["compare"]
+
+    # Build descriptive output
+    output_lines = ["# Page Comparison Result\n"]
+
+    # Source information
+    from_info = []
+    if "fromtitle" in compare_data:
+        from_info.append(f"Title: {compare_data['fromtitle']}")
+    if "fromid" in compare_data:
+        from_info.append(f"ID: {compare_data['fromid']}")
+    if "fromrevid" in compare_data:
+        from_info.append(f"Revision: {compare_data['fromrevid']}")
+    if "fromns" in compare_data:
+        from_info.append(f"Namespace: {compare_data['fromns']}")
+
+    output_lines.append(f"**From:** {', '.join(from_info) if from_info else 'Unknown'}")
+
+    # Target information
+    to_info = []
+    if "totitle" in compare_data:
+        to_info.append(f"Title: {compare_data['totitle']}")
+    if "toid" in compare_data:
+        to_info.append(f"ID: {compare_data['toid']}")
+    if "torevid" in compare_data:
+        to_info.append(f"Revision: {compare_data['torevid']}")
+    if "tons" in compare_data:
+        to_info.append(f"Namespace: {compare_data['tons']}")
+
+    output_lines.append(f"**To:** {', '.join(to_info) if to_info else 'Unknown'}")
+    output_lines.append("")
+
+    # Add diff format information
+    difftype = arguments.get("difftype", "default")
+    output_lines.append(f"**Diff format:** {difftype}")
+    output_lines.append("")
+
+    # Add diff content if available
+    if "body" in compare_data:
+        output_lines.append("## Comparison Output\n")
+        output_lines.append(compare_data["body"])
+    elif "*" in compare_data:
+        # Handle legacy format
+        output_lines.append("## Comparison Output\n")
+        output_lines.append(compare_data["*"])
+    else:
+        # Check for other possible diff fields
+        diff_fields = ["diff", "text", "html"]
+        for field in diff_fields:
+            if field in compare_data:
+                output_lines.append(f"## {field.title()} Comparison\n")
+                output_lines.append(str(compare_data[field]))
+                break
+        else:
+            output_lines.append("## Raw API Response\n")
+            output_lines.append(str(compare_data))
+
+    # Add metadata if available
+    metadata = []
+    if "fromsize" in compare_data:
+        metadata.append(f"From size: {compare_data['fromsize']} bytes")
+    if "tosize" in compare_data:
+        metadata.append(f"To size: {compare_data['tosize']} bytes")
+
+    if metadata:
+        output_lines.append("\n## Metadata\n")
+        output_lines.extend(metadata)
+
+    formatted_output = "\n".join(output_lines)
+
+    return [types.TextContent(
+        type="text",
+        text=formatted_output
+    )]

--- a/mediawiki_api_mcp/server.py
+++ b/mediawiki_api_mcp/server.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from .config import MediaWikiConfig
 from .server_tools.wiki_meta_siteinfo import register_wiki_meta_siteinfo_tool
 from .server_tools.wiki_opensearch import register_wiki_opensearch_tool
+from .server_tools.wiki_page_compare import register_wiki_page_compare_tool
 from .server_tools.wiki_page_delete import register_wiki_page_delete_tool
 from .server_tools.wiki_page_edit import register_wiki_page_edit_tool
 from .server_tools.wiki_page_get import register_wiki_page_get_tool
@@ -48,6 +49,7 @@ def get_config() -> MediaWikiConfig:
 register_wiki_page_edit_tool(mcp, get_config)
 register_wiki_page_get_tool(mcp, get_config)
 register_wiki_page_parse_tool(mcp, get_config)
+register_wiki_page_compare_tool(mcp, get_config)
 register_wiki_search_tool(mcp, get_config)
 register_wiki_opensearch_tool(mcp, get_config)
 register_wiki_page_move_tool(mcp, get_config)

--- a/mediawiki_api_mcp/server_tools/wiki_page_compare.py
+++ b/mediawiki_api_mcp/server_tools/wiki_page_compare.py
@@ -89,15 +89,15 @@ def register_wiki_page_compare_tool(mcp: FastMCP, get_config: Callable[[], Media
                 if fromtitle:
                     arguments["fromtitle"] = fromtitle
                 if fromid:
-                    arguments["fromid"] = fromid
+                    arguments["fromid"] = str(fromid)
                 if fromrev:
-                    arguments["fromrev"] = fromrev
+                    arguments["fromrev"] = str(fromrev)
                 if totitle:
                     arguments["totitle"] = totitle
                 if toid:
-                    arguments["toid"] = toid
+                    arguments["toid"] = str(toid)
                 if torev:
-                    arguments["torev"] = torev
+                    arguments["torev"] = str(torev)
 
                 # Slot and output parameters
                 if fromslots:
@@ -143,9 +143,9 @@ def register_wiki_page_compare_tool(mcp: FastMCP, get_config: Callable[[], Media
                 if tosection_main:
                     arguments["tosection-main"] = tosection_main
                 if frompst_main:
-                    arguments["frompst-main"] = frompst_main
+                    arguments["frompst-main"] = str(frompst_main).lower()
                 if topst_main:
-                    arguments["topst-main"] = topst_main
+                    arguments["topst-main"] = str(topst_main).lower()
 
                 result = await handle_compare_page(client, arguments)
                 # Return the formatted text from the handler

--- a/mediawiki_api_mcp/server_tools/wiki_page_compare.py
+++ b/mediawiki_api_mcp/server_tools/wiki_page_compare.py
@@ -1,0 +1,155 @@
+"""Wiki page compare tool for MediaWiki API MCP integration."""
+
+import logging
+from collections.abc import Callable
+
+from mcp.server.fastmcp import FastMCP
+
+from ..client import MediaWikiClient
+from ..config import MediaWikiConfig
+
+logger = logging.getLogger(__name__)
+
+
+def register_wiki_page_compare_tool(mcp: FastMCP, get_config: Callable[[], MediaWikiConfig]) -> None:
+    """Register the wiki_page_compare tool with the MCP server."""
+
+    @mcp.tool()
+    async def wiki_page_compare(
+        fromtitle: str = "",
+        fromid: int = 0,
+        fromrev: int = 0,
+        totitle: str = "",
+        toid: int = 0,
+        torev: int = 0,
+        fromslots: str = "",
+        toslots: str = "",
+        prop: str = "",
+        difftype: str = "",
+        fromtext: str = "",
+        totext: str = "",
+        fromcontentformat: str = "",
+        tocontentformat: str = "",
+        fromcontentmodel: str = "",
+        tocontentmodel: str = "",
+        tosection: str = "",
+        # Slot-specific parameters
+        fromtext_main: str = "",
+        totext_main: str = "",
+        fromcontentformat_main: str = "",
+        tocontentformat_main: str = "",
+        fromcontentmodel_main: str = "",
+        tocontentmodel_main: str = "",
+        fromsection_main: str = "",
+        tosection_main: str = "",
+        frompst_main: bool = False,
+        topst_main: bool = False,
+    ) -> str:
+        """Compare two revisions of wiki pages or arbitrary content.
+
+        Args:
+            fromtitle: First title to compare
+            fromid: First page ID to compare
+            fromrev: First revision to compare
+            totitle: Second title to compare
+            toid: Second page ID to compare
+            torev: Second revision to compare
+            fromslots: Specify slots to be modified (pipe-separated)
+            toslots: Specify slots to be modified (pipe-separated)
+            prop: Which pieces of information to return (use '*' for all)
+            difftype: Format of diff output ('inline', 'table', 'unified')
+            fromtext: Legacy - Text content for 'from' side (deprecated)
+            totext: Legacy - Text content for 'to' side (deprecated)
+            fromcontentformat: Legacy - Content format for 'from' side (deprecated)
+            tocontentformat: Legacy - Content format for 'to' side (deprecated)
+            fromcontentmodel: Legacy - Content model for 'from' side (deprecated)
+            tocontentmodel: Legacy - Content model for 'to' side (deprecated)
+            tosection: Legacy - Section identifier for 'to' side (deprecated)
+            fromtext_main: Text content for the main slot on 'from' side
+            totext_main: Text content for the main slot on 'to' side
+            fromcontentformat_main: Content format for main slot on 'from' side
+            tocontentformat_main: Content format for main slot on 'to' side
+            fromcontentmodel_main: Content model for main slot on 'from' side
+            tocontentmodel_main: Content model for main slot on 'to' side
+            fromsection_main: Section for main slot on 'from' side
+            tosection_main: Section for main slot on 'to' side
+            frompst_main: Pre-save transform for main slot on 'from' side
+            topst_main: Pre-save transform for main slot on 'to' side
+        """
+        try:
+            config = get_config()
+            async with MediaWikiClient(config) as client:
+                # Import here to avoid circular imports
+                from ..handlers import handle_compare_page
+
+                # Convert FastMCP parameters to handler arguments
+                arguments = {}
+
+                # Basic page identification parameters
+                if fromtitle:
+                    arguments["fromtitle"] = fromtitle
+                if fromid:
+                    arguments["fromid"] = fromid
+                if fromrev:
+                    arguments["fromrev"] = fromrev
+                if totitle:
+                    arguments["totitle"] = totitle
+                if toid:
+                    arguments["toid"] = toid
+                if torev:
+                    arguments["torev"] = torev
+
+                # Slot and output parameters
+                if fromslots:
+                    arguments["fromslots"] = fromslots
+                if toslots:
+                    arguments["toslots"] = toslots
+                if prop:
+                    arguments["prop"] = prop
+                if difftype:
+                    arguments["difftype"] = difftype
+
+                # Legacy parameters
+                if fromtext:
+                    arguments["fromtext"] = fromtext
+                if totext:
+                    arguments["totext"] = totext
+                if fromcontentformat:
+                    arguments["fromcontentformat"] = fromcontentformat
+                if tocontentformat:
+                    arguments["tocontentformat"] = tocontentformat
+                if fromcontentmodel:
+                    arguments["fromcontentmodel"] = fromcontentmodel
+                if tocontentmodel:
+                    arguments["tocontentmodel"] = tocontentmodel
+                if tosection:
+                    arguments["tosection"] = tosection
+
+                # Slot-specific parameters (main slot)
+                if fromtext_main:
+                    arguments["fromtext-main"] = fromtext_main
+                if totext_main:
+                    arguments["totext-main"] = totext_main
+                if fromcontentformat_main:
+                    arguments["fromcontentformat-main"] = fromcontentformat_main
+                if tocontentformat_main:
+                    arguments["tocontentformat-main"] = tocontentformat_main
+                if fromcontentmodel_main:
+                    arguments["fromcontentmodel-main"] = fromcontentmodel_main
+                if tocontentmodel_main:
+                    arguments["tocontentmodel-main"] = tocontentmodel_main
+                if fromsection_main:
+                    arguments["fromsection-main"] = fromsection_main
+                if tosection_main:
+                    arguments["tosection-main"] = tosection_main
+                if frompst_main:
+                    arguments["frompst-main"] = frompst_main
+                if topst_main:
+                    arguments["topst-main"] = topst_main
+
+                result = await handle_compare_page(client, arguments)
+                # Return the formatted text from the handler
+                return result[0].text if result else "No results"
+        except Exception as e:
+            logger.error(f"Wiki page compare failed: {e}")
+            return f"Error: {str(e)}"

--- a/tests/test_wiki_page_compare.py
+++ b/tests/test_wiki_page_compare.py
@@ -1,0 +1,271 @@
+"""Test suite for MediaWiki page comparison handlers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mediawiki_api_mcp.client import MediaWikiClient
+from mediawiki_api_mcp.handlers.wiki_page_compare import handle_compare_page
+
+
+class TestCompareHandlers:
+    """Test cases for page comparison handlers."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock MediaWiki client."""
+        client = MagicMock(spec=MediaWikiClient)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_success_basic(self, mock_client):
+        """Test successful page comparison with basic parameters."""
+        # Setup mock response
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "fromid": 123,
+                "fromrevid": 456,
+                "fromns": 0,
+                "totitle": "Page B",
+                "toid": 789,
+                "torevid": 12,
+                "tons": 0,
+                "body": "<tr><td colspan='2' width='50%' align='center' class='diff-otitle'>Revision as of 10:00, 1 January 2024</td><td colspan='2' width='50%' align='center' class='diff-ntitle'>Revision as of 11:00, 1 January 2024</td></tr><tr><td>-</td><td class='diff-deletedline'><div>Old content</div></td><td>+</td><td class='diff-addedline'><div>New content</div></td></tr>"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B",
+            "difftype": "table"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "# Page Comparison Result" in result[0].text
+        assert "**From:** Title: Page A, ID: 123, Revision: 456, Namespace: 0" in result[0].text
+        assert "**To:** Title: Page B, ID: 789, Revision: 12, Namespace: 0" in result[0].text
+        assert "**Diff format:** table" in result[0].text
+        assert "## Comparison Output" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_success_revisions(self, mock_client):
+        """Test successful page comparison between specific revisions."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromrevid": 100,
+                "torevid": 200,
+                "fromtitle": "Example Page",
+                "totitle": "Example Page",
+                "body": "<table class='diff'><tr><td>Example diff content</td></tr></table>"
+            }
+        }
+
+        arguments = {
+            "fromrev": 100,
+            "torev": 200,
+            "difftype": "table"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "**From:** Title: Example Page, Revision: 100" in result[0].text
+        assert "**To:** Title: Example Page, Revision: 200" in result[0].text
+        assert "Example diff content" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_with_slot_params(self, mock_client):
+        """Test page comparison with slot-specific parameters."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "totitle": "Page A",
+                "body": "Slot-based comparison result"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "toslots": "main",
+            "totext-main": "Modified content",
+            "tocontentmodel-main": "wikitext",
+            "frompst-main": True,
+            "difftype": "unified"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "# Page Comparison Result" in result[0].text
+        assert "**Diff format:** unified" in result[0].text
+
+        # Verify that slot parameters were passed to the client
+        mock_client.compare_page.assert_called_once()
+        call_args = mock_client.compare_page.call_args
+        assert call_args[1]["fromtitle"] == "Page A"
+        assert call_args[1]["toslots"] == "main"
+        assert call_args[1]["slot_params"]["totext-main"] == "Modified content"
+        assert call_args[1]["slot_params"]["tocontentmodel-main"] == "wikitext"
+        assert call_args[1]["slot_params"]["frompst-main"] is True
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_legacy_parameters(self, mock_client):
+        """Test page comparison with legacy parameters."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Test Page",
+                "totitle": "Test Page",
+                "*": "Legacy format diff content"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Test Page",
+            "totext": "New content",
+            "fromcontentformat": "text/x-wiki",
+            "tocontentmodel": "wikitext",
+            "tosection": "1"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Legacy format diff content" in result[0].text
+
+        # Verify legacy parameters were passed correctly
+        mock_client.compare_page.assert_called_once()
+        call_args = mock_client.compare_page.call_args
+        assert call_args[1]["totext"] == "New content"
+        assert call_args[1]["fromcontentformat"] == "text/x-wiki"
+        assert call_args[1]["tocontentmodel"] == "wikitext"
+        assert call_args[1]["tosection"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_with_metadata(self, mock_client):
+        """Test page comparison result with metadata."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "totitle": "Page B",
+                "fromsize": 1024,
+                "tosize": 2048,
+                "diff": "Diff content with metadata"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B",
+            "prop": "*"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "## Metadata" in result[0].text
+        assert "From size: 1024 bytes" in result[0].text
+        assert "To size: 2048 bytes" in result[0].text
+        assert "## Diff Comparison" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_unexpected_response(self, mock_client):
+        """Test handling of unexpected API response format."""
+        mock_client.compare_page.return_value = {
+            "error": "Invalid parameters"
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Error: Unexpected response format from MediaWiki Compare API" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_raw_response_fallback(self, mock_client):
+        """Test fallback to raw response when expected fields are missing."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "totitle": "Page B",
+                "someunknownfield": "Unknown data structure"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "## Raw API Response" in result[0].text
+        assert "someunknownfield" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_exception(self, mock_client):
+        """Test handling of client exceptions."""
+        mock_client.compare_page.side_effect = Exception("Network error")
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "Error comparing pages: Network error" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_multiple_diff_fields(self, mock_client):
+        """Test handling of different diff field formats."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "totitle": "Page B",
+                "text": "Text format diff content"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B",
+            "difftype": "inline"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "## Text Comparison" in result[0].text
+        assert "Text format diff content" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_compare_page_html_diff(self, mock_client):
+        """Test handling of HTML diff format."""
+        mock_client.compare_page.return_value = {
+            "compare": {
+                "fromtitle": "Page A",
+                "totitle": "Page B",
+                "html": "<div class='diff-html'>HTML diff content</div>"
+            }
+        }
+
+        arguments = {
+            "fromtitle": "Page A",
+            "totitle": "Page B",
+            "difftype": "table"
+        }
+
+        result = await handle_compare_page(mock_client, arguments)
+
+        assert len(result) == 1
+        assert "## Html Comparison" in result[0].text
+        assert "<div class='diff-html'>HTML diff content</div>" in result[0].text


### PR DESCRIPTION
>Implement the `wiki_page_compare` MCP tool according to the attached spec of the MediaWiki Compare API.

```git-revs
d1c15a1  (Base revision)
7d693c8  Add compare_page method to MediaWikiPageClient with full Compare API support
9be685f  Create handler for wiki_page_compare tool
8bc505d  Create server tool for wiki_page_compare
6626b05  Add wiki_page_compare handler to handlers __init__.py
114f956  Add wiki_page_compare tool to server registration
HEAD     Register wiki_page_compare tool in server
```

codemcp-id: 56-feat-implement-wiki-page-compare-mcp-tool

>Complete the implementation of the wiki_page_compare MCP tool according to the MediaWiki Compare API specification

```git-revs
c805838  (Base revision)
bef7cb1  Add compare_page delegation method to MediaWikiClient
ce4ce82  Create comprehensive test suite for MediaWiki compare handlers
35cd27b  Create comprehensive documentation for wiki_page_compare tool
056cf6e  Fix syntax error in test file - change 012 to 12
HEAD     Fix test assertion to match updated revision ID
```

codemcp-id: 57-feat-complete-wiki-page-compare-tool-implementatio